### PR TITLE
fix: validate plex token placeholder

### DIFF
--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -157,7 +157,7 @@ def _load_plex_config(config: configparser.ConfigParser) -> Dict[str, str]:
     if config.has_section('plex'):
         plex_url = config.get('plex', 'plex_url', fallback=None)
         plex_token = config.get('plex', 'plex_token', fallback=None)
-        if plex_url and plex_token and plex_token != "YOUR_PEX_TOKEN_HERE":
+        if plex_url and plex_token and plex_token != "YOUR_PLEX_TOKEN_HERE":
             plex_config = {'url': plex_url, 'token': plex_token}
             logger.info("[INFO] Plex configuration loaded successfully.")
     return plex_config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import configparser
+
+# Ensure the project root is on sys.path to allow importing telegram_bot
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from telegram_bot.config import _load_plex_config
+
+
+def test_load_plex_config_ignores_placeholder():
+    config = configparser.ConfigParser()
+    config.add_section('plex')
+    config.set('plex', 'plex_url', 'http://example.com')
+    config.set('plex', 'plex_token', 'YOUR_PLEX_TOKEN_HERE')
+    assert _load_plex_config(config) == {}


### PR DESCRIPTION
## Summary
- ensure placeholder Plex API tokens are ignored when loading configuration
- add regression test for placeholder token handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689991b95afc8326972a8a70addd8903