### PR TITLE
test: add parser tests

### DIFF
--- a/tests/services/test_media_manager.py
+++ b/tests/services/test_media_manager.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
+import pytest
+from telegram_bot.services.media_manager import (
+    generate_plex_filename,
+    parse_resolution_from_name,
+)
+
+
+def test_generate_plex_filename_movie():
+    parsed = {"type": "movie", "title": "Inception", "year": "2010"}
+    assert generate_plex_filename(parsed, ".mkv") == "Inception (2010).mkv"
+
+
+def test_generate_plex_filename_tv_with_episode_title():
+    parsed = {
+        "type": "tv",
+        "title": "My Show",
+        "season": 1,
+        "episode": 2,
+        "episode_title": "Pilot",
+    }
+    assert generate_plex_filename(parsed, ".mp4") == "s01e02 - Pilot.mp4"
+
+
+def test_generate_plex_filename_illegal_chars():
+    parsed = {"type": "movie", "title": "Bad:Title*?", "year": "2020"}
+    assert generate_plex_filename(parsed, ".mp4") == "BadTitle (2020).mp4"
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("Movie.2160p.BluRay", "4K"),
+        ("Video.1080p.x265", "1080p"),
+        ("Series.720p.HDTV", "720p"),
+        ("Old.Movie.DVDRip", "SD"),
+        ("Sample", "N/A"),
+    ],
+)
+def test_parse_resolution_from_name(name, expected):
+    assert parse_resolution_from_name(name) == expected

--- a/tests/services/test_search_logic.py
+++ b/tests/services/test_search_logic.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
+import pytest
+from telegram_bot.services.search_logic import (
+    _parse_codec,
+    _parse_size_to_gb,
+    score_torrent_result,
+)
+
+
+@pytest.mark.parametrize(
+    "title, expected",
+    [
+        ("Some.Movie.x265", "x265"),
+        ("Another HEVC release", "x265"),
+        ("Film X264 edition", "x264"),
+        ("No codec here", None),
+    ],
+)
+def test_parse_codec(title, expected):
+    assert _parse_codec(title) == expected
+
+
+@pytest.mark.parametrize(
+    "size_str, expected",
+    [
+        ("1.5 GB", 1.5),
+        ("500 MB", 500 / 1024),
+        ("1024 KB", 1024 / (1024 * 1024)),
+        ("invalid", 0.0),
+    ],
+)
+def test_parse_size_to_gb(size_str, expected):
+    assert _parse_size_to_gb(size_str) == pytest.approx(expected)
+
+
+def test_score_torrent_result():
+    prefs = {
+        "codecs": {"x265": 10},
+        "resolutions": {"1080p": 5},
+        "uploaders": {"trusted": 20},
+    }
+    score = score_torrent_result("Great Movie 1080p x265", "trusted", prefs, seeders=7)
+    assert score == 42  # 10 + 5 + 20 + 7
+
+    no_match = score_torrent_result("Another 720p x264", "unknown", prefs, seeders=3)
+    assert no_match == 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 import pytest
-from telegram_bot.utils import format_bytes, extract_first_int
+from telegram_bot.utils import format_bytes, extract_first_int, parse_torrent_name
 
 # Use pytest's "parametrize" to test many cases with one function
 @pytest.mark.parametrize("size_bytes, expected_str", [
@@ -29,3 +29,30 @@ def test_format_bytes(size_bytes, expected_str):
 def test_extract_first_int(text, expected_int):
     """Verify that extract_first_int correctly pulls the first integer."""
     assert extract_first_int(text) == expected_int
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("Movie.Title.2023", {"type": "movie", "title": "Movie Title", "year": "2023"}),
+        (
+            "Show.Name.S01E02.1080p",
+            {"type": "tv", "title": "Show Name", "season": 1, "episode": 2},
+        ),
+        (
+            "Show Name 1x02 [1080p]",
+            {"type": "tv", "title": "Show Name", "season": 1, "episode": 2},
+        ),
+        (
+            "Another_Show-S01E02_[x265]",
+            {"type": "tv", "title": "Another Show", "season": 1, "episode": 2},
+        ),
+        (
+            "Unknown.File[x265]",
+            {"type": "unknown", "title": "Unknown File"},
+        ),
+    ],
+)
+def test_parse_torrent_name(name, expected):
+    """Verify that torrent names are parsed into the correct metadata."""
+    assert parse_torrent_name(name) == expected


### PR DESCRIPTION
## Summary
- add parse_torrent_name coverage to utils tests
- add media manager filename and resolution tests
- add search logic parser and scoring tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999ca1485483268bdef496daebb71f