### PR TITLE
test: add handler routing tests

### DIFF
--- a/tests/handlers/test_callback_handlers.py
+++ b/tests/handlers/test_callback_handlers.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram import Update, CallbackQuery
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
+from telegram_bot.handlers.callback_handlers import button_handler
+
+
+@pytest.mark.asyncio
+async def test_button_handler_routes_search(mocker, make_callback_query, context, make_message):
+    mocker.patch.object(CallbackQuery, "answer", AsyncMock())
+    query = make_callback_query("search_start_movie", make_message())
+    update = Update(update_id=1, callback_query=query)
+
+    mocker.patch(
+        "telegram_bot.handlers.callback_handlers.is_user_authorized",
+        AsyncMock(return_value=True),
+    )
+    handler_mock = mocker.patch(
+        "telegram_bot.handlers.callback_handlers.handle_search_buttons",
+        AsyncMock(),
+    )
+
+    await button_handler(update, context)
+
+    handler_mock.assert_awaited_once_with(update, context)
+
+
+@pytest.mark.asyncio
+async def test_button_handler_routes_delete(mocker, make_callback_query, context, make_message):
+    mocker.patch.object(CallbackQuery, "answer", AsyncMock())
+    query = make_callback_query("delete_start_tv", make_message())
+    update = Update(update_id=1, callback_query=query)
+
+    mocker.patch(
+        "telegram_bot.handlers.callback_handlers.is_user_authorized",
+        AsyncMock(return_value=True),
+    )
+    handler_mock = mocker.patch(
+        "telegram_bot.handlers.callback_handlers.handle_delete_buttons",
+        AsyncMock(),
+    )
+
+    await button_handler(update, context)
+
+    handler_mock.assert_awaited_once_with(update, context)
+
+
+@pytest.mark.asyncio
+async def test_button_handler_routes_download(mocker, make_callback_query, context, make_message):
+    mocker.patch.object(CallbackQuery, "answer", AsyncMock())
+    query = make_callback_query("confirm_download", make_message())
+    update = Update(update_id=1, callback_query=query)
+
+    mocker.patch(
+        "telegram_bot.handlers.callback_handlers.is_user_authorized",
+        AsyncMock(return_value=True),
+    )
+    handler_mock = mocker.patch(
+        "telegram_bot.handlers.callback_handlers.add_download_to_queue",
+        AsyncMock(),
+    )
+
+    await button_handler(update, context)
+
+    handler_mock.assert_awaited_once_with(update, context)

--- a/tests/handlers/test_command_handlers.py
+++ b/tests/handlers/test_command_handlers.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram import Update, Message
+
+# Ensure root path for imports
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
+from telegram_bot.handlers.command_handlers import search_command, plex_status_command
+
+
+@pytest.mark.asyncio
+async def test_search_command_starts_workflow(mocker, make_message, context):
+    update = Update(update_id=1, message=make_message("/search"))
+
+    mocker.patch(
+        "telegram_bot.handlers.command_handlers.is_user_authorized",
+        AsyncMock(return_value=True),
+    )
+    reply_mock = mocker.patch.object(Message, "reply_text", AsyncMock())
+
+    await search_command(update, context)
+
+    reply_mock.assert_awaited_once()
+    assert context.user_data.get("active_workflow") == "search"
+
+
+@pytest.mark.asyncio
+async def test_plex_status_command_calls_service(mocker, make_message, context):
+    status_msg = make_message()
+    context.bot.send_message.return_value = status_msg
+
+    update = Update(update_id=1, message=make_message("/status"))
+
+    mocker.patch(
+        "telegram_bot.handlers.command_handlers.is_user_authorized",
+        AsyncMock(return_value=True),
+    )
+    service_mock = mocker.patch(
+        "telegram_bot.handlers.command_handlers.get_plex_server_status",
+        AsyncMock(return_value="All good"),
+    )
+
+    await plex_status_command(update, context)
+
+    service_mock.assert_awaited_once_with(context)

--- a/tests/handlers/test_message_handlers.py
+++ b/tests/handlers/test_message_handlers.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram import Update, Message
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
+from telegram_bot.handlers.message_handlers import handle_link_message, handle_search_message
+
+
+@pytest.mark.asyncio
+async def test_handle_link_message_processes_input(mocker, make_message, context):
+    msg = make_message("magnet:?xt=urn:btih:abcdef")
+    update = Update(update_id=1, message=msg)
+
+    mocker.patch(
+        "telegram_bot.handlers.message_handlers.is_user_authorized",
+        AsyncMock(return_value=True),
+    )
+    reply_msg = make_message()
+    reply_mock = mocker.patch.object(Message, "reply_text", AsyncMock(return_value=reply_msg))
+    process_mock = mocker.patch(
+        "telegram_bot.handlers.message_handlers.process_user_input",
+        AsyncMock(return_value="ti"),
+    )
+    validate_mock = mocker.patch(
+        "telegram_bot.handlers.message_handlers.validate_and_enrich_torrent",
+        AsyncMock(return_value=(None, {"type": "movie"})),
+    )
+    confirm_mock = mocker.patch(
+        "telegram_bot.handlers.message_handlers.send_confirmation_prompt",
+        AsyncMock(),
+    )
+
+    await handle_link_message(update, context)
+
+    reply_mock.assert_awaited_once()
+    process_mock.assert_awaited_once_with("magnet:?xt=urn:btih:abcdef", context, reply_msg)
+    validate_mock.assert_awaited_once_with("ti", reply_msg)
+    confirm_mock.assert_awaited_once_with(reply_msg, context, "ti", {"type": "movie"})
+
+
+@pytest.mark.asyncio
+async def test_handle_search_message_routes_search(mocker, make_message, context):
+    msg = make_message("query")
+    update = Update(update_id=1, message=msg)
+
+    mocker.patch(
+        "telegram_bot.handlers.message_handlers.is_user_authorized",
+        AsyncMock(return_value=True),
+    )
+    handler_mock = mocker.patch(
+        "telegram_bot.handlers.message_handlers.handle_search_workflow",
+        AsyncMock(),
+    )
+    context.user_data["active_workflow"] = "search"
+
+    await handle_search_message(update, context)
+
+    handler_mock.assert_awaited_once_with(update, context)
+
+
+@pytest.mark.asyncio
+async def test_handle_search_message_routes_delete(mocker, make_message, context):
+    msg = make_message("query")
+    update = Update(update_id=1, message=msg)
+
+    mocker.patch(
+        "telegram_bot.handlers.message_handlers.is_user_authorized",
+        AsyncMock(return_value=True),
+    )
+    handler_mock = mocker.patch(
+        "telegram_bot.handlers.message_handlers.handle_delete_workflow",
+        AsyncMock(),
+    )
+    context.user_data["active_workflow"] = "delete"
+
+    await handle_search_message(update, context)
+
+    handler_mock.assert_awaited_once_with(update, context)


### PR DESCRIPTION
## Summary
- add unit tests for command handlers to ensure search and Plex status commands delegate correctly
- cover message handler routing for links and workflow-specific text messages
- verify callback button routing for search, delete, and download actions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899a2fad20c83268802af25f559d758