### PR TITLE
Add pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,27 @@
-repos: []
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0 # Use the latest version
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+
+-   repo: https://github.com/psf/black
+    rev: 23.3.0 # Use the latest version
+    hooks:
+    -   id: black
+
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.278 # Use the latest version
+    hooks:
+    -   id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+
+-   repo: local
+    hooks:
+    -   id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- run tests before commit via pre-commit
- format and lint with black and ruff

## Testing
- `pre-commit run --files .pre-commit-config.yaml` *(failed: CalledProcessError: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ad76c60e883269ed969efaed8776f