### PR TITLE
refactor: move sys.path setup before imports

### DIFF
--- a/tests/handlers/test_callback_handlers.py
+++ b/tests/handlers/test_callback_handlers.py
@@ -2,10 +2,11 @@ import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
 
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
 import pytest
 from telegram import Update, CallbackQuery
 
-sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
 from telegram_bot.handlers.callback_handlers import button_handler
 

--- a/tests/handlers/test_command_handlers.py
+++ b/tests/handlers/test_command_handlers.py
@@ -2,11 +2,12 @@ import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
 
+# Ensure root path for imports
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
 import pytest
 from telegram import Update, Message
 
-# Ensure root path for imports
-sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
 from telegram_bot.handlers.command_handlers import search_command, plex_status_command
 

--- a/tests/handlers/test_error_handler.py
+++ b/tests/handlers/test_error_handler.py
@@ -3,10 +3,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
 import pytest
 from telegram import Message
 
-sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
 from telegram_bot.handlers.error_handler import global_error_handler
 

--- a/tests/handlers/test_message_handlers.py
+++ b/tests/handlers/test_message_handlers.py
@@ -2,10 +2,11 @@ import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
 
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
 import pytest
 from telegram import Update, Message
 
-sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
 from telegram_bot.handlers.message_handlers import handle_link_message, handle_search_message
 

--- a/tests/services/test_download_manager.py
+++ b/tests/services/test_download_manager.py
@@ -1,12 +1,13 @@
-from pathlib import Path
 import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
 import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, ANY
 
 import pytest
-
-sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
 from telegram_bot.services.download_manager import (
     ProgressReporter,
@@ -16,6 +17,7 @@ from telegram_bot.services.download_manager import (
     handle_pause_request,
     handle_resume_request,
 )
+
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_media_manager.py
+++ b/tests/services/test_media_manager.py
@@ -1,14 +1,16 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
 import pytest
+
 from telegram_bot.services.media_manager import (
     generate_plex_filename,
     parse_resolution_from_name,
     handle_successful_download,
 )
+
 
 
 def test_generate_plex_filename_movie():

--- a/tests/services/test_plex_service.py
+++ b/tests/services/test_plex_service.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from plexapi.exceptions import Unauthorized
 
 from telegram_bot.services.plex_service import get_plex_server_status
+
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_scraping_service.py
+++ b/tests/services/test_scraping_service.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
@@ -10,6 +10,7 @@ from telegram_bot.services.scraping_service import (
     scrape_1337x,
     scrape_yts,
 )
+
 
 
 class DummyResponse:

--- a/tests/services/test_search_logic.py
+++ b/tests/services/test_search_logic.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
@@ -9,6 +9,7 @@ from telegram_bot.services.search_logic import (
     _parse_size_to_gb,
     score_torrent_result,
 )
+
 
 
 @pytest.mark.parametrize(

--- a/tests/services/test_torrent_service.py
+++ b/tests/services/test_torrent_service.py
@@ -1,17 +1,18 @@
-from pathlib import Path
 import sys
-from unittest.mock import AsyncMock
-
-import pytest
-from telegram import InlineKeyboardMarkup
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+
+from unittest.mock import AsyncMock
+import pytest
+from telegram import InlineKeyboardMarkup
 
 from telegram_bot.services.torrent_service import (
     process_user_input,
     _handle_webpage_url,
     fetch_metadata_from_magnet,
 )
+
 
 
 # -------- process_user_input routing ---------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,13 @@
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
+import pytest
+
 from telegram_bot.config import get_configuration
+
+
 
 
 def test_get_configuration_happy_path(mocker):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,12 +1,13 @@
-import json
 import sys
 from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-
-sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from telegram_bot.state import (
     load_state,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 


### PR DESCRIPTION
## Summary
- ensure sys.path adjustments happen before imports in test modules

## Testing
- `ruff check --select E402 tests`
- `pre-commit run --files tests/handlers/test_callback_handlers.py` *(fails: CalledProcessError: git fetch origin --tags, exit code 128)*

------
https://chatgpt.com/codex/tasks/task_e_689ae394bdf4832698ac011ff51fe7f4