### PR TITLE
feat: support season pack downloads

### DIFF
--- a/telegram_bot/services/download_manager.py
+++ b/telegram_bot/services/download_manager.py
@@ -540,11 +540,15 @@ async def add_season_to_queue(update, context):
     if chat_id_str not in download_queues:
         download_queues[chat_id_str] = []
 
-    for link in pending_list:
+    for torrent_data in pending_list:
+        link = torrent_data.get("link")
+        if not link:
+            continue
+        parsed_info = torrent_data.get("parsed_info", {})
         source_dict = {
             "value": link,
             "type": "magnet" if link.startswith("magnet:") else "url",
-            "parsed_info": {},
+            "parsed_info": parsed_info,
             "original_message_id": query.message.message_id,
         }
         download_data = {

--- a/tests/services/test_download_manager.py
+++ b/tests/services/test_download_manager.py
@@ -224,7 +224,10 @@ async def test_add_season_to_queue(
     message = make_message(message_id=20)
     callback = make_callback_query(data="confirm_season_download", message=message)
     update = make_update(callback_query=callback)
-    context.user_data["pending_season_download"] = ["magnet1", "magnet2"]
+    context.user_data["pending_season_download"] = [
+        {"link": "magnet1", "parsed_info": {"episode": 1}},
+        {"link": "magnet2", "parsed_info": {"episode": 2}},
+    ]
     context.bot_data["active_downloads"] = {}
     context.bot_data["download_queues"] = {}
     context.bot_data["SAVE_PATHS"] = {"default": "/tmp"}
@@ -244,6 +247,7 @@ async def test_add_season_to_queue(
 
     q = context.bot_data["download_queues"][str(message.chat.id)]
     assert len(q) == 2
+    assert q[0]["source_dict"]["parsed_info"]["episode"] == 1
     process_mock.assert_awaited_once_with(message.chat.id, context.application)
 
 


### PR DESCRIPTION
## Summary
- add season pack detection during search and propagate metadata
- store rich torrent info in download queue and handle season packs during post-processing
- add coverage for season packs and episode fallback

## Testing
- `pre-commit run --files telegram_bot/workflows/search_workflow.py telegram_bot/services/download_manager.py telegram_bot/services/media_manager.py tests/workflows/test_search_workflow.py tests/services/test_download_manager.py tests/services/test_media_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ea6bbe4308326b18753cdc0e3916c