### PR TITLE
Use generic scraper for non-specialized sites

### DIFF
--- a/telegram_bot/services/scraping_service.py
+++ b/telegram_bot/services/scraping_service.py
@@ -1,7 +1,6 @@
 # telegram_bot/services/scraping_service.py
 
 import asyncio
-from collections import Counter
 import re
 import urllib.parse
 from typing import Any
@@ -347,186 +346,6 @@ async def fetch_season_episode_count_from_wikipedia(
 # --- Torrent Site Scraping ---
 
 
-async def scrape_1337x(
-    query: str,
-    media_type: str,
-    search_url_template: str,
-    context: ContextTypes.DEFAULT_TYPE,
-    *,
-    base_query_for_filter: str | None = None,
-    **kwargs,
-) -> list[dict[str, Any]]:
-    """
-    Scrapes 1337x.to for torrents. It now correctly performs all network
-    requests within a single client session to prevent closure errors.
-    """
-    search_config = context.bot_data.get("SEARCH_CONFIG", {})
-    prefs_key = "movies" if "movie" in media_type else "tv"
-    preferences = search_config.get("preferences", {}).get(prefs_key, {})
-
-    if not preferences:
-        logger.warning(
-            f"[SCRAPER] No preferences found for '{prefs_key}'. Cannot score 1337x results."
-        )
-        return []
-
-    formatted_query = urllib.parse.quote_plus(query)
-    search_url = search_url_template.replace("{query}", formatted_query)
-    headers = {
-        "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36",
-    }
-
-    results = []
-    best_match_base_name = "N/A"
-
-    try:
-        # CORRECTED: The 'async with' block now wraps ALL network activity.
-        async with httpx.AsyncClient(
-            headers=headers, timeout=30, follow_redirects=True
-        ) as client:
-            # --- Initial Search Request ---
-            logger.info(
-                f"[SCRAPER] 1337x Stage 1: Scraping candidates from {search_url}"
-            )
-            response = await client.get(search_url)
-            response.raise_for_status()
-            soup = BeautifulSoup(response.text, "lxml")
-
-            # --- Stage 1: Scrape candidates ---
-            candidates = []
-            table_body = soup.find("tbody")
-            if not isinstance(table_body, Tag):
-                return []
-
-            for row in table_body.find_all("tr"):
-                if not isinstance(row, Tag) or len(row.find_all("td")) < 2:
-                    continue
-                name_cell = row.find_all("td")[0]
-                if (
-                    not isinstance(name_cell, Tag)
-                    or len(links := name_cell.find_all("a")) < 2
-                ):
-                    continue
-                title = links[1].get_text(strip=True)
-                parsed_info = parse_torrent_name(title)
-                base_name = parsed_info.get("title")
-                if title and base_name:
-                    candidates.append(
-                        {
-                            "title": title,
-                            "base_name": base_name,
-                            "row_element": row,
-                            "parsed_info": parsed_info,
-                        }
-                    )
-
-            if not candidates:
-                logger.warning("[SCRAPER] 1337x: Found no candidates on page.")
-                return []
-
-            # --- Stage 2: Identify best match ---
-            filter_query = base_query_for_filter or query
-            candidates = [
-                c
-                for c in candidates
-                if fuzz.ratio(filter_query.lower(), c["base_name"].lower()) > 85
-            ]
-
-            if not candidates:
-                logger.warning(
-                    f"[SCRAPER] 1337x: No candidates survived fuzzy filter for query '{query}'."
-                )
-                return []
-
-            base_name_counts = Counter(c["base_name"] for c in candidates)
-            if not base_name_counts:
-                return []
-
-            best_match_base_name, _ = base_name_counts.most_common(1)[0]
-            logger.info(
-                f"[SCRAPER] 1337x Stage 2: Identified most common media name: '{best_match_base_name}'"
-            )
-
-            # --- Stage 3: Fetch detail pages and process torrents ---
-            base_url = "https://1337x.to"
-            for candidate in candidates:
-                if candidate["base_name"] == best_match_base_name:
-                    row = candidate["row_element"]
-                    cells = row.find_all("td")
-                    if len(cells) < 6:
-                        continue
-
-                    name_cell, seeds_cell, size_cell, uploader_cell = (
-                        cells[0],
-                        cells[1],
-                        cells[4],
-                        cells[5],
-                    )
-                    page_url_relative = name_cell.find_all("a")[1].get("href")
-                    if not isinstance(page_url_relative, str):
-                        continue
-
-                    detail_page_url = f"{base_url}{page_url_relative}"
-
-                    # This request now happens inside the active client session.
-                    detail_response = await client.get(detail_page_url)
-                    if detail_response.status_code != 200:
-                        logger.warning(
-                            f"Failed to fetch 1337x detail page {detail_page_url}, status: {detail_response.status_code}"
-                        )
-                        continue
-
-                    detail_soup = BeautifulSoup(detail_response.text, "lxml")
-                    magnet_tag = detail_soup.find("a", href=re.compile(r"^magnet:"))
-                    if (
-                        not magnet_tag
-                        or not isinstance(magnet_tag, Tag)
-                        or not (magnet_link := magnet_tag.get("href"))
-                    ):
-                        logger.warning(
-                            f"Could not find magnet link on page: {detail_page_url}"
-                        )
-                        continue
-
-                    # Process the rest of the data
-                    size_str = size_cell.get_text(strip=True)
-                    seeds_str = seeds_cell.get_text(strip=True)
-                    parsed_size_gb = _parse_size_to_gb(size_str)
-                    uploader = (
-                        uploader_cell.find("a").get_text(strip=True)
-                        if uploader_cell.find("a")
-                        else "Anonymous"
-                    )
-                    seeders_int = int(seeds_str) if seeds_str.isdigit() else 0
-                    score = score_torrent_result(
-                        candidate["title"], uploader, preferences, seeders=seeders_int
-                    )
-
-                    if score > 0 and isinstance(magnet_link, str):
-                        results.append(
-                            {
-                                "title": candidate["title"],
-                                "page_url": magnet_link,
-                                "score": score,
-                                "source": "1337x",
-                                "uploader": uploader,
-                                "size_gb": parsed_size_gb,
-                                "codec": _parse_codec(candidate["title"]),
-                                "seeders": seeders_int,
-                                "year": candidate["parsed_info"].get("year"),
-                            }
-                        )
-
-    except Exception as e:
-        logger.error(f"[SCRAPER ERROR] 1337x scrape failed: {e}", exc_info=True)
-        return []
-
-    logger.info(
-        f"[SCRAPER] 1337x Stage 3: Found {len(results)} relevant torrents for '{best_match_base_name}'."
-    )
-    return results
-
-
 async def scrape_yts(
     query: str,
     media_type: str,
@@ -734,33 +553,38 @@ async def find_magnet_link_on_page(url: str) -> list[str]:
 # --- Generic Web Scraper Strategies ---
 
 
-def _strategy_find_direct_links(soup: BeautifulSoup) -> set[str]:
-    """Find anchors that directly link to magnet or ``.torrent`` files."""
+def _extract_row_data(row: Tag, link_tag: Tag) -> dict[str, Any]:
+    """Extracts basic torrent data from a table row."""
 
-    found_links: set[str] = set()
-    # Anchor tags are the most reliable indicators of downloadable content.
-    for tag in soup.find_all("a", href=True):
-        if isinstance(tag, Tag):  # Add this check
-            href = tag.get("href")
-            if not isinstance(href, str):
-                continue
-            if href.startswith("magnet:"):
-                found_links.add(href)
-            elif href.endswith(".torrent"):
-                # Relative ``.torrent`` paths are returned as-is; the caller may resolve them.
-                found_links.add(href)
-    return found_links
+    cells = row.find_all("td")
+    cell_texts = [cell.get_text(" ", strip=True) for cell in cells]
+
+    def _int_from_cell(index: int) -> int:
+        return (
+            extract_first_int(cell_texts[index]) or 0 if len(cell_texts) > index else 0
+        )
+
+    return {
+        "title": link_tag.get_text(strip=True),
+        "link": link_tag.get("href"),
+        "seeders": _int_from_cell(1),
+        "leechers": _int_from_cell(2),
+        "size": cell_texts[3] if len(cell_texts) > 3 else "",
+        "uploader": cell_texts[4] if len(cell_texts) > 4 else "Unknown",
+    }
 
 
-def _strategy_contextual_search(soup: BeautifulSoup, query: str) -> set[str]:
+def _strategy_contextual_search(
+    soup: BeautifulSoup, query: str
+) -> list[dict[str, Any]]:
     """Find links whose surrounding text hints at a torrent download."""
 
     if not isinstance(query, str) or not query.strip():
-        return set()
+        return []
 
-    potential_links: set[str] = set()
     keywords = {"magnet", "torrent", "download", "1080p", "720p", "x265"}
     query_lc = query.lower()
+    results: list[dict[str, Any]] = []
 
     for tag in soup.find_all("a", href=True):
         if not isinstance(tag, Tag):
@@ -787,18 +611,20 @@ def _strategy_contextual_search(soup: BeautifulSoup, query: str) -> set[str]:
         )
 
         if keyword_match or query_match > 80:
-            potential_links.add(href)
+            row = tag.find_parent("tr")
+            if isinstance(row, Tag):
+                results.append(_extract_row_data(row, tag))
 
-    return potential_links
+    return results
 
 
-def _strategy_find_in_tables(soup: BeautifulSoup, query: str) -> dict[str, float]:
-    """Inspect tables for rows relevant to ``query`` and score their links."""
+def _strategy_find_in_tables(soup: BeautifulSoup, query: str) -> list[dict[str, Any]]:
+    """Inspect tables for rows relevant to ``query``."""
 
     if not isinstance(query, str) or not query.strip():
-        return {}
+        return []
 
-    scored_links: dict[str, float] = {}
+    results: list[dict[str, Any]] = []
     query_lc = query.lower()
 
     for table in soup.find_all("table"):
@@ -815,64 +641,18 @@ def _strategy_find_in_tables(soup: BeautifulSoup, query: str) -> dict[str, float
                 continue
             first_link = row.find("a", href=True)
             if first_link and isinstance(first_link, Tag):
-                href = first_link.get("href")
-                if isinstance(href, str):
-                    scored_links[href] = float(match_score)
+                results.append(_extract_row_data(row, first_link))
 
-    return scored_links
-
-
-def _score_candidate_links(
-    links: set[str],
-    query: str,
-    table_links_scored: dict[str, float],
-    soup: BeautifulSoup,
-) -> str | None:
-    """Score candidate links and return the highest scoring URL."""
-
-    if not links or not isinstance(query, str) or not query.strip():
-        return None
-
-    query_lc = query.lower()
-    best_link: str | None = None
-    best_score = -1.0
-
-    for link in links:
-        score = 0.0
-
-        if link.startswith("magnet:"):
-            score += 100
-        elif link.endswith(".torrent"):
-            score += 50
-
-        score += table_links_scored.get(link, 0)
-
-        anchor = soup.find("a", href=link)
-        if anchor:
-            link_text_lc = anchor.get_text(strip=True).lower()
-            score += fuzz.partial_ratio(query_lc, link_text_lc)
-
-            # Penalise links that live inside obvious ad/comment containers.
-            parent = anchor.parent
-            while isinstance(parent, Tag):
-                classes = " ".join(parent.get("class") or []).lower()
-                element_id = str(parent.get("id") or "").lower()
-                if "ad" in classes or "ads" in classes or "comment" in element_id:
-                    score -= 50
-                    break
-                parent = parent.parent
-
-        if score > best_score:
-            best_score = score
-            best_link = link
-
-    return best_link
+    return results
 
 
 async def scrape_generic_page(
-    query: str, media_type: str, search_url: str
+    query: str,
+    media_type: str,
+    search_url: str,
+    preferences: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
-    """High-level orchestrator that runs all strategies and selects the best link."""
+    """Scrape a generic torrent site and return formatted results."""
 
     if not query.strip() or not search_url.strip():
         return []
@@ -882,13 +662,41 @@ async def scrape_generic_page(
         return []
 
     soup = BeautifulSoup(html, "lxml")
-    direct_links = _strategy_find_direct_links(soup)
-    context_links = _strategy_contextual_search(soup, query)
-    table_links_scored = _strategy_find_in_tables(soup, query)
+    candidates = _strategy_find_in_tables(soup, query) + _strategy_contextual_search(
+        soup, query
+    )
 
-    all_candidates = direct_links | context_links | set(table_links_scored)
-    best_link = _score_candidate_links(all_candidates, query, table_links_scored, soup)
+    preferences = preferences or {}
+    results = []
+    seen_urls: set[str] = set()
+    for item in candidates:
+        title = item.get("title")
+        link = item.get("link")
+        if not title or not link:
+            continue
+        page_url = urllib.parse.urljoin(search_url, link)
+        if page_url in seen_urls:
+            continue
+        seen_urls.add(page_url)
+        size_str = item.get("size", "")
+        uploader = item.get("uploader", "Unknown")
+        seeders = item.get("seeders", 0)
+        parsed_info = parse_torrent_name(title)
+        size_gb = _parse_size_to_gb(size_str)
+        codec = _parse_codec(title)
+        score = score_torrent_result(title, uploader, preferences, seeders=seeders)
+        results.append(
+            {
+                "title": title,
+                "page_url": page_url,
+                "score": score,
+                "source": "generic",
+                "uploader": uploader,
+                "size_gb": size_gb,
+                "codec": codec,
+                "seeders": seeders,
+                "year": parsed_info.get("year"),
+            }
+        )
 
-    if best_link:
-        return [{"page_url": best_link, "source": "generic"}]
-    return []
+    return results

--- a/telegram_bot/services/search_logic.py
+++ b/telegram_bot/services/search_logic.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import re
+import urllib.parse
 from typing import Any
 from collections.abc import Callable, Coroutine
 
@@ -42,11 +43,11 @@ async def orchestrate_searches(
         )
         return []
 
-    # A dedicated scraper for EZTV would need to be created in the future.
     scraper_map: dict[str, ScraperFunction] = {
-        "1337x": scraping_service.scrape_1337x,
         "YTS.mx": scraping_service.scrape_yts,
     }
+
+    preferences = search_config.get("preferences", {}).get(config_key, {})
 
     tasks = []
     for site_info in sites_to_scrape:
@@ -73,11 +74,6 @@ async def orchestrate_searches(
                 continue
 
             search_query = query
-            year = kwargs.get("year")
-
-            # Only append the year for the 1337x scraper.
-            if site_name == "1337x" and year:
-                search_query += f" {year}"
 
             scraper_func = scraper_map.get(site_name)
 
@@ -86,36 +82,32 @@ async def orchestrate_searches(
                     f"[SEARCH] Creating search task for '{site_name}' with query: '{query}'"
                 )
 
-                # Allow callers to override the string used for fuzzy filtering. This
-                # is useful for episode-specific searches where the query contains
-                # season/episode tokens that would otherwise reduce the match score.
-                base_filter = kwargs.get("base_query_for_filter", query)
                 extra_kwargs = {
                     k: v for k, v in kwargs.items() if k != "base_query_for_filter"
                 }
 
-                if site_name == "1337x":
-                    task = asyncio.create_task(
-                        scraper_func(
-                            search_query,
-                            media_type,
-                            site_url,
-                            context,
-                            base_query_for_filter=base_filter,
-                            **extra_kwargs,
-                        )
+                task = asyncio.create_task(
+                    scraper_func(
+                        search_query, media_type, site_url, context, **extra_kwargs
                     )
-                else:
-                    task = asyncio.create_task(
-                        scraper_func(
-                            search_query, media_type, site_url, context, **extra_kwargs
-                        )
-                    )
+                )
                 tasks.append(task)
             else:
-                logger.warning(
-                    f"[SEARCH] Configured site '{site_name}' has no corresponding scraper function. It will be ignored."
+                logger.info(
+                    f"[SEARCH] Using generic scraper as fallback for '{site_name}'."
                 )
+                scraper_func = scraping_service.scrape_generic_page
+                formatted_query = urllib.parse.quote_plus(search_query)
+                search_url_final = site_url.replace("{query}", formatted_query)
+                task = asyncio.create_task(
+                    scraper_func(
+                        search_query,
+                        media_type,
+                        search_url_final,
+                        preferences,
+                    )
+                )
+                tasks.append(task)
 
     if not tasks:
         logger.warning("[SEARCH] No enabled search sites found to orchestrate.")

--- a/tests/services/test_scraping_service.py
+++ b/tests/services/test_scraping_service.py
@@ -177,83 +177,56 @@ async def test_fetch_season_episode_count(mocker):
 
 
 @pytest.mark.asyncio
-async def test_scrape_1337x_parses_results(mocker):
-    # This is the response for the initial search results page
-    search_html = """
-    <table><tbody>
-    <tr>
-      <td>
-        <a href="/cat">Movies</a>
-        <a href="/torrent/1/Sample.Movie.2023.1080p.x265/">Sample.Movie.2023.1080p.x265</a>
-      </td>
-      <td>10</td><td>0</td><td>0</td><td>1.5 GB</td><td><a>Anonymous</a></td>
-    </tr>
-    </tbody></table>
+async def test_scrape_generic_page_parses_results(mocker):
+    html = """
+    <table>
+      <tr>
+        <td><a href="/torrent/1">Sample.Show.S01E01.1080p.x265</a></td>
+        <td>10</td><td>5</td><td>1.2 GB</td><td>Uploader1</td>
+      </tr>
+    </table>
     """
 
-    # This is the required second response for the torrent detail page
-    detail_html = """
-    <div>
-      <a href="magnet:?xt=urn:btih:FAKEHASH">Magnet Download</a>
-    </div>
-    """
+    mocker.patch(
+        "telegram_bot.services.scraping_service._get_page_html",
+        return_value=html,
+    )
 
-    # The mock client now has TWO responses to give, and they will have a default status_code of 200
-    responses = [DummyResponse(text=search_html), DummyResponse(text=detail_html)]
-    mocker.patch("httpx.AsyncClient", return_value=DummyClient(responses))
-
-    context = Mock()
-    context.bot_data = {
-        "SEARCH_CONFIG": {
-            "preferences": {
-                "movies": {
-                    "codecs": {"x265": 5},
-                    "resolutions": {"1080p": 3},
-                    "uploaders": {"Anonymous": 2},
-                }
-            }
-        }
+    prefs = {
+        "codecs": {"x265": 5},
+        "resolutions": {"1080p": 3},
+        "uploaders": {"Uploader1": 2},
     }
 
-    results = await scraping_service.scrape_1337x(
-        "Sample Movie 2023",
-        "movie",
-        "https://1337x.to/search/{query}/1/",
-        context,
-        base_query_for_filter="Sample Movie",
+    results = await scraping_service.scrape_generic_page(
+        "Sample Show S01E01",
+        "tv",
+        "https://example.com/search",
+        prefs,
     )
 
     assert len(results) == 1
-    assert results[0]["title"] == "Sample.Movie.2023.1080p.x265"
-    assert results[0]["page_url"].startswith("magnet:")
-    assert results[0]["source"] == "1337x"
+    result = results[0]
+    assert result["title"] == "Sample.Show.S01E01.1080p.x265"
+    assert result["source"] == "generic"
+    assert result["seeders"] == 10
+    assert result["size_gb"] == pytest.approx(1.2)
+    assert result["score"] > 0
 
 
 @pytest.mark.asyncio
-async def test_scrape_1337x_no_results(mocker):
+async def test_scrape_generic_page_no_results(mocker):
     html = "<html><body>No results</body></html>"
-    responses = [DummyResponse(text=html)]
-    mocker.patch("httpx.AsyncClient", return_value=DummyClient(responses))
+    mocker.patch(
+        "telegram_bot.services.scraping_service._get_page_html",
+        return_value=html,
+    )
 
-    context = Mock()
-    context.bot_data = {
-        "SEARCH_CONFIG": {
-            "preferences": {
-                "movies": {
-                    "codecs": {},
-                    "resolutions": {},
-                    "uploaders": {},
-                }
-            }
-        }
-    }
-
-    results = await scraping_service.scrape_1337x(
+    results = await scraping_service.scrape_generic_page(
         "Sample",
-        "movie",
-        "https://1337x.to/search/{query}/1/",
-        context,  # Pass the mock object here
-        base_query_for_filter="Sample Movie",
+        "tv",
+        "https://example.com/search",
+        {},
     )
 
     assert results == []
@@ -320,53 +293,32 @@ async def test_scrape_yts_parses_results(mocker):
     assert results[0]["seeders"] == 10
 
 
-def test_strategy_find_direct_links_magnet():
-    html = '<a href="magnet:?xt=urn:btih:123">Magnet</a>'
-    soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_find_direct_links(soup)
-    assert links == {"magnet:?xt=urn:btih:123"}
-
-
-def test_strategy_find_direct_links_torrent():
-    html = '<a href="https://example.com/file.torrent">Download</a>'
-    soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_find_direct_links(soup)
-    assert links == {"https://example.com/file.torrent"}
-
-
-def test_strategy_find_direct_links_none():
-    html = '<a href="/other">Link</a>'
-    soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_find_direct_links(soup)
-    assert links == set()
-
-
 def test_strategy_contextual_search_keyword():
-    html = '<a href="/download/123">Download Torrent</a>'
+    html = '<table><tr><td><a href="/download/123">Download Torrent</a></td><td>1</td><td>2</td><td>1 GB</td><td>U</td></tr></table>'
     soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_contextual_search(soup, "Query")
-    assert "/download/123" in links
+    results = scraping_service._strategy_contextual_search(soup, "Query")
+    assert any(r["link"] == "/download/123" for r in results)
 
 
 def test_strategy_contextual_search_query_match():
-    html = '<a href="/details.php?id=456">My Show S01E01 1080p</a>'
+    html = '<table><tr><td><a href="/details.php?id=456">My Show S01E01 1080p</a></td><td>1</td><td>2</td><td>1 GB</td><td>U</td></tr></table>'
     soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_contextual_search(soup, "My Show")
-    assert "/details.php?id=456" in links
+    results = scraping_service._strategy_contextual_search(soup, "My Show")
+    assert any(r["link"] == "/details.php?id=456" for r in results)
 
 
 def test_strategy_contextual_search_unrelated_keyword():
-    html = '<a href="/about">About our download policy</a>'
+    html = '<table><tr><td><a href="/about">About our download policy</a></td><td>1</td><td>2</td><td>1 GB</td><td>U</td></tr></table>'
     soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_contextual_search(soup, "My Show")
-    assert "/about" in links
+    results = scraping_service._strategy_contextual_search(soup, "My Show")
+    assert any(r["link"] == "/about" for r in results)
 
 
 def test_strategy_find_in_tables_single_match():
     html = '<table><tr><td>My Show</td><td><a href="/dl">Download</a></td></tr></table>'
     soup = BeautifulSoup(html, "lxml")
-    results = scraping_service._strategy_find_in_tables(soup, "My Show")
-    assert "/dl" in results
+    rows = scraping_service._strategy_find_in_tables(soup, "My Show")
+    assert any(r["link"] == "/dl" for r in rows)
 
 
 def test_strategy_find_in_tables_multiple_matches():
@@ -377,8 +329,9 @@ def test_strategy_find_in_tables_multiple_matches():
     </table>
     """
     soup = BeautifulSoup(html, "lxml")
-    results = scraping_service._strategy_find_in_tables(soup, "My Show")
-    assert {"/e1", "/e2"}.issubset(results.keys())
+    rows = scraping_service._strategy_find_in_tables(soup, "My Show")
+    links = {r["link"] for r in rows}
+    assert {"/e1", "/e2"}.issubset(links)
 
 
 def test_strategy_find_in_tables_ignores_unrelated_tables():
@@ -387,40 +340,6 @@ def test_strategy_find_in_tables_ignores_unrelated_tables():
     <table><tr><td>My Show</td><td><a href="/dl">Download</a></td></tr></table>
     """
     soup = BeautifulSoup(html, "lxml")
-    results = scraping_service._strategy_find_in_tables(soup, "My Show")
-    assert "/dl" in results and "/x" not in results
-
-
-def test_score_candidate_links_prefers_magnet():
-    html = (
-        '<div><a href="magnet:?xt=urn:btih:1">Magnet</a></div>'
-        '<div><a href="/context">Download Torrent</a></div>'
-        '<table><tr><td>My Show</td><td><a href="/table">Link</a></td></tr></table>'
-    )
-    soup = BeautifulSoup(html, "lxml")
-    links = {"magnet:?xt=urn:btih:1", "/context", "/table"}
-    table_links = {"/table": 80.0}
-    best = scraping_service._score_candidate_links(links, "My Show", table_links, soup)
-    assert best == "magnet:?xt=urn:btih:1"
-
-
-def test_score_candidate_links_penalizes_ads():
-    html = (
-        '<div class="ad"><a href="/bad">My Show 1080p</a></div>'
-        '<div><a href="/good">My Show 1080p</a></div>'
-    )
-    soup = BeautifulSoup(html, "lxml")
-    links = {"/bad", "/good"}
-    best = scraping_service._score_candidate_links(links, "My Show", {}, soup)
-    assert best == "/good"
-
-
-def test_score_candidate_links_prefers_better_match():
-    html = (
-        '<div><a href="/high">My Show Episode</a></div>'
-        '<div><a href="/low">Another Show</a></div>'
-    )
-    soup = BeautifulSoup(html, "lxml")
-    links = {"/high", "/low"}
-    best = scraping_service._score_candidate_links(links, "My Show Episode", {}, soup)
-    assert best == "/high"
+    rows = scraping_service._strategy_find_in_tables(soup, "My Show")
+    links = {r["link"] for r in rows}
+    assert "/dl" in links and "/x" not in links


### PR DESCRIPTION
## Summary
- route unknown sites through the generic scraper with URL-encoded queries
- enhance generic scraper to parse table rows and compute scores; drop dedicated 1337x logic
- add tests covering generic scraping behavior and update strategy tests

## Testing
- `pre-commit run --files telegram_bot/services/scraping_service.py tests/services/test_scraping_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4151a929c83268c6ab30cda2c1109