### PR TITLE
feat: enhance generic scraping and unify search

### DIFF
--- a/telegram_bot/services/scraping_service.py
+++ b/telegram_bot/services/scraping_service.py
@@ -1,10 +1,9 @@
 # telegram_bot/services/scraping_service.py
 
 import asyncio
-from collections import Counter
 import re
 import urllib.parse
-from typing import Any
+from typing import Any, List, Dict
 
 import httpx
 import wikipedia
@@ -14,7 +13,7 @@ from thefuzz import fuzz, process
 
 from ..config import logger
 from .search_logic import _parse_codec, _parse_size_to_gb, score_torrent_result
-from ..utils import extract_first_int, parse_torrent_name
+from ..utils import extract_first_int
 
 
 # --- Helper Functions ---
@@ -347,186 +346,6 @@ async def fetch_season_episode_count_from_wikipedia(
 # --- Torrent Site Scraping ---
 
 
-async def scrape_1337x(
-    query: str,
-    media_type: str,
-    search_url_template: str,
-    context: ContextTypes.DEFAULT_TYPE,
-    *,
-    base_query_for_filter: str | None = None,
-    **kwargs,
-) -> list[dict[str, Any]]:
-    """
-    Scrapes 1337x.to for torrents. It now correctly performs all network
-    requests within a single client session to prevent closure errors.
-    """
-    search_config = context.bot_data.get("SEARCH_CONFIG", {})
-    prefs_key = "movies" if "movie" in media_type else "tv"
-    preferences = search_config.get("preferences", {}).get(prefs_key, {})
-
-    if not preferences:
-        logger.warning(
-            f"[SCRAPER] No preferences found for '{prefs_key}'. Cannot score 1337x results."
-        )
-        return []
-
-    formatted_query = urllib.parse.quote_plus(query)
-    search_url = search_url_template.replace("{query}", formatted_query)
-    headers = {
-        "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36",
-    }
-
-    results = []
-    best_match_base_name = "N/A"
-
-    try:
-        # CORRECTED: The 'async with' block now wraps ALL network activity.
-        async with httpx.AsyncClient(
-            headers=headers, timeout=30, follow_redirects=True
-        ) as client:
-            # --- Initial Search Request ---
-            logger.info(
-                f"[SCRAPER] 1337x Stage 1: Scraping candidates from {search_url}"
-            )
-            response = await client.get(search_url)
-            response.raise_for_status()
-            soup = BeautifulSoup(response.text, "lxml")
-
-            # --- Stage 1: Scrape candidates ---
-            candidates = []
-            table_body = soup.find("tbody")
-            if not isinstance(table_body, Tag):
-                return []
-
-            for row in table_body.find_all("tr"):
-                if not isinstance(row, Tag) or len(row.find_all("td")) < 2:
-                    continue
-                name_cell = row.find_all("td")[0]
-                if (
-                    not isinstance(name_cell, Tag)
-                    or len(links := name_cell.find_all("a")) < 2
-                ):
-                    continue
-                title = links[1].get_text(strip=True)
-                parsed_info = parse_torrent_name(title)
-                base_name = parsed_info.get("title")
-                if title and base_name:
-                    candidates.append(
-                        {
-                            "title": title,
-                            "base_name": base_name,
-                            "row_element": row,
-                            "parsed_info": parsed_info,
-                        }
-                    )
-
-            if not candidates:
-                logger.warning("[SCRAPER] 1337x: Found no candidates on page.")
-                return []
-
-            # --- Stage 2: Identify best match ---
-            filter_query = base_query_for_filter or query
-            candidates = [
-                c
-                for c in candidates
-                if fuzz.ratio(filter_query.lower(), c["base_name"].lower()) > 85
-            ]
-
-            if not candidates:
-                logger.warning(
-                    f"[SCRAPER] 1337x: No candidates survived fuzzy filter for query '{query}'."
-                )
-                return []
-
-            base_name_counts = Counter(c["base_name"] for c in candidates)
-            if not base_name_counts:
-                return []
-
-            best_match_base_name, _ = base_name_counts.most_common(1)[0]
-            logger.info(
-                f"[SCRAPER] 1337x Stage 2: Identified most common media name: '{best_match_base_name}'"
-            )
-
-            # --- Stage 3: Fetch detail pages and process torrents ---
-            base_url = "https://1337x.to"
-            for candidate in candidates:
-                if candidate["base_name"] == best_match_base_name:
-                    row = candidate["row_element"]
-                    cells = row.find_all("td")
-                    if len(cells) < 6:
-                        continue
-
-                    name_cell, seeds_cell, size_cell, uploader_cell = (
-                        cells[0],
-                        cells[1],
-                        cells[4],
-                        cells[5],
-                    )
-                    page_url_relative = name_cell.find_all("a")[1].get("href")
-                    if not isinstance(page_url_relative, str):
-                        continue
-
-                    detail_page_url = f"{base_url}{page_url_relative}"
-
-                    # This request now happens inside the active client session.
-                    detail_response = await client.get(detail_page_url)
-                    if detail_response.status_code != 200:
-                        logger.warning(
-                            f"Failed to fetch 1337x detail page {detail_page_url}, status: {detail_response.status_code}"
-                        )
-                        continue
-
-                    detail_soup = BeautifulSoup(detail_response.text, "lxml")
-                    magnet_tag = detail_soup.find("a", href=re.compile(r"^magnet:"))
-                    if (
-                        not magnet_tag
-                        or not isinstance(magnet_tag, Tag)
-                        or not (magnet_link := magnet_tag.get("href"))
-                    ):
-                        logger.warning(
-                            f"Could not find magnet link on page: {detail_page_url}"
-                        )
-                        continue
-
-                    # Process the rest of the data
-                    size_str = size_cell.get_text(strip=True)
-                    seeds_str = seeds_cell.get_text(strip=True)
-                    parsed_size_gb = _parse_size_to_gb(size_str)
-                    uploader = (
-                        uploader_cell.find("a").get_text(strip=True)
-                        if uploader_cell.find("a")
-                        else "Anonymous"
-                    )
-                    seeders_int = int(seeds_str) if seeds_str.isdigit() else 0
-                    score = score_torrent_result(
-                        candidate["title"], uploader, preferences, seeders=seeders_int
-                    )
-
-                    if score > 0 and isinstance(magnet_link, str):
-                        results.append(
-                            {
-                                "title": candidate["title"],
-                                "page_url": magnet_link,
-                                "score": score,
-                                "source": "1337x",
-                                "uploader": uploader,
-                                "size_gb": parsed_size_gb,
-                                "codec": _parse_codec(candidate["title"]),
-                                "seeders": seeders_int,
-                                "year": candidate["parsed_info"].get("year"),
-                            }
-                        )
-
-    except Exception as e:
-        logger.error(f"[SCRAPER ERROR] 1337x scrape failed: {e}", exc_info=True)
-        return []
-
-    logger.info(
-        f"[SCRAPER] 1337x Stage 3: Found {len(results)} relevant torrents for '{best_match_base_name}'."
-    )
-    return results
-
-
 async def scrape_yts(
     query: str,
     media_type: str,
@@ -752,13 +571,16 @@ def _strategy_find_direct_links(soup: BeautifulSoup) -> set[str]:
     return found_links
 
 
-def _strategy_contextual_search(soup: BeautifulSoup, query: str) -> set[str]:
+def _strategy_contextual_search(
+    soup: BeautifulSoup, query: str
+) -> List[Dict[str, Any]]:
     """Find links whose surrounding text hints at a torrent download."""
 
     if not isinstance(query, str) or not query.strip():
-        return set()
+        return []
 
-    potential_links: set[str] = set()
+    results: List[Dict[str, Any]] = []
+    seen_urls: set[str] = set()
     keywords = {"magnet", "torrent", "download", "1080p", "720p", "x265"}
     query_lc = query.lower()
 
@@ -767,7 +589,7 @@ def _strategy_contextual_search(soup: BeautifulSoup, query: str) -> set[str]:
             continue
 
         href = tag.get("href")
-        if not isinstance(href, str):
+        if not isinstance(href, str) or href in seen_urls:
             continue
 
         text_lc = tag.get_text(strip=True).lower()
@@ -787,18 +609,56 @@ def _strategy_contextual_search(soup: BeautifulSoup, query: str) -> set[str]:
         )
 
         if keyword_match or query_match > 80:
-            potential_links.add(href)
+            if (
+                not keyword_match
+                and query_lc not in text_lc
+                and query_lc not in href_lc
+            ):
+                continue
+            row = tag.find_parent("tr")
+            seeders = leechers = 0
+            size = ""
+            uploader = "Unknown"
+            if isinstance(row, Tag):
+                cells = row.find_all("td")
+                seeders = (
+                    extract_first_int(cells[1].get_text(strip=True))
+                    if len(cells) > 1
+                    else 0
+                )
+                leechers = (
+                    extract_first_int(cells[2].get_text(strip=True))
+                    if len(cells) > 2
+                    else 0
+                )
+                size = cells[3].get_text(strip=True) if len(cells) > 3 else ""
+                uploader = (
+                    cells[4].get_text(strip=True) if len(cells) > 4 else "Unknown"
+                )
 
-    return potential_links
+            results.append(
+                {
+                    "page_url": href,
+                    "title": tag.get_text(strip=True) or query,
+                    "seeders": seeders,
+                    "leechers": leechers,
+                    "size": size,
+                    "uploader": uploader,
+                }
+            )
+            seen_urls.add(href)
+
+    return results
 
 
-def _strategy_find_in_tables(soup: BeautifulSoup, query: str) -> dict[str, float]:
-    """Inspect tables for rows relevant to ``query`` and score their links."""
+def _strategy_find_in_tables(soup: BeautifulSoup, query: str) -> List[Dict[str, Any]]:
+    """Inspect tables for rows relevant to ``query`` and extract torrent data."""
 
     if not isinstance(query, str) or not query.strip():
-        return {}
+        return []
 
-    scored_links: dict[str, float] = {}
+    results: List[Dict[str, Any]] = []
+    seen_urls: set[str] = set()
     query_lc = query.lower()
 
     for table in soup.find_all("table"):
@@ -810,69 +670,54 @@ def _strategy_find_in_tables(soup: BeautifulSoup, query: str) -> dict[str, float
                 continue
 
             row_text = row.get_text(" ", strip=True)
-            match_score = fuzz.partial_ratio(query_lc, row_text.lower())
-            if match_score <= 75:
+            if fuzz.partial_ratio(query_lc, row_text.lower()) <= 75:
                 continue
-            first_link = row.find("a", href=True)
-            if first_link and isinstance(first_link, Tag):
-                href = first_link.get("href")
-                if isinstance(href, str):
-                    scored_links[href] = float(match_score)
+            links_in_row = row.find_all("a", href=True)
+            if not links_in_row:
+                continue
+            link_tag = links_in_row[-1]
+            if not isinstance(link_tag, Tag):
+                continue
+            href = link_tag.get("href")
+            if not isinstance(href, str) or href in seen_urls:
+                continue
 
-    return scored_links
+            cells = row.find_all("td")
+            seeders = (
+                extract_first_int(cells[1].get_text(strip=True))
+                if len(cells) > 1
+                else 0
+            )
+            leechers = (
+                extract_first_int(cells[2].get_text(strip=True))
+                if len(cells) > 2
+                else 0
+            )
+            size = cells[3].get_text(strip=True) if len(cells) > 3 else ""
+            uploader = cells[4].get_text(strip=True) if len(cells) > 4 else "Unknown"
 
+            results.append(
+                {
+                    "page_url": href,
+                    "title": link_tag.get_text(strip=True) or query,
+                    "seeders": seeders,
+                    "leechers": leechers,
+                    "size": size,
+                    "uploader": uploader,
+                }
+            )
+            seen_urls.add(href)
 
-def _score_candidate_links(
-    links: set[str],
-    query: str,
-    table_links_scored: dict[str, float],
-    soup: BeautifulSoup,
-) -> str | None:
-    """Score candidate links and return the highest scoring URL."""
-
-    if not links or not isinstance(query, str) or not query.strip():
-        return None
-
-    query_lc = query.lower()
-    best_link: str | None = None
-    best_score = -1.0
-
-    for link in links:
-        score = 0.0
-
-        if link.startswith("magnet:"):
-            score += 100
-        elif link.endswith(".torrent"):
-            score += 50
-
-        score += table_links_scored.get(link, 0)
-
-        anchor = soup.find("a", href=link)
-        if anchor:
-            link_text_lc = anchor.get_text(strip=True).lower()
-            score += fuzz.partial_ratio(query_lc, link_text_lc)
-
-            # Penalise links that live inside obvious ad/comment containers.
-            parent = anchor.parent
-            while isinstance(parent, Tag):
-                classes = " ".join(parent.get("class") or []).lower()
-                element_id = str(parent.get("id") or "").lower()
-                if "ad" in classes or "ads" in classes or "comment" in element_id:
-                    score -= 50
-                    break
-                parent = parent.parent
-
-        if score > best_score:
-            best_score = score
-            best_link = link
-
-    return best_link
+    return results
 
 
 async def scrape_generic_page(
-    query: str, media_type: str, search_url: str
+    query: str,
+    media_type: str,
+    search_url: str,
+    preferences: Dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
-    """High-level orchestrator that runs all strategies and selects the best link."""
+    """Scrape a generic search results page and return formatted torrent data."""
 
     if not query.strip() or not search_url.strip():
         return []
@@ -882,13 +727,70 @@ async def scrape_generic_page(
         return []
 
     soup = BeautifulSoup(html, "lxml")
-    direct_links = _strategy_find_direct_links(soup)
-    context_links = _strategy_contextual_search(soup, query)
-    table_links_scored = _strategy_find_in_tables(soup, query)
 
-    all_candidates = direct_links | context_links | set(table_links_scored)
-    best_link = _score_candidate_links(all_candidates, query, table_links_scored, soup)
+    raw_items: List[Dict[str, Any]] = []
+    raw_items.extend(_strategy_find_in_tables(soup, query))
+    raw_items.extend(_strategy_contextual_search(soup, query))
 
-    if best_link:
-        return [{"page_url": best_link, "source": "generic"}]
-    return []
+    # Include direct magnet links that may exist on the page without metadata.
+    for link in _strategy_find_direct_links(soup):
+        raw_items.append(
+            {
+                "page_url": link,
+                "title": query,
+                "seeders": 0,
+                "leechers": 0,
+                "size": "",
+                "uploader": "Unknown",
+            }
+        )
+
+    if not raw_items:
+        return []
+
+    unique_items: List[Dict[str, Any]] = []
+    seen_pages: set[str] = set()
+    for item in raw_items:
+        page = item.get("page_url")
+        if isinstance(page, str) and page not in seen_pages:
+            seen_pages.add(page)
+            unique_items.append(item)
+    raw_items = unique_items
+
+    preferences = preferences or {}
+    results: list[dict[str, Any]] = []
+    source = urllib.parse.urlparse(search_url).netloc or "generic"
+
+    for item in raw_items:
+        page_url = item.get("page_url", "")
+        full_url = urllib.parse.urljoin(search_url, page_url)
+        title = item.get("title") or query
+        uploader = item.get("uploader", "Unknown")
+        seeders = int(item.get("seeders") or 0)
+        size_str = item.get("size", "")
+        size_gb = _parse_size_to_gb(size_str)
+        codec = _parse_codec(title)
+
+        magnet_links: List[str] = []
+        if full_url.startswith("magnet:") or full_url.endswith(".torrent"):
+            magnet_links = [full_url]
+        else:
+            magnet_links = await find_magnet_link_on_page(full_url)
+
+        for magnet in magnet_links:
+            score = score_torrent_result(title, uploader, preferences, seeders=seeders)
+            results.append(
+                {
+                    "title": title,
+                    "page_url": magnet,
+                    "score": score,
+                    "source": source,
+                    "uploader": uploader,
+                    "size_gb": size_gb,
+                    "codec": codec,
+                    "seeders": seeders,
+                    "year": None,
+                }
+            )
+
+    return results

--- a/tests/services/test_scraping_service.py
+++ b/tests/services/test_scraping_service.py
@@ -3,7 +3,7 @@
 import sys
 from pathlib import Path
 import pytest
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 import wikipedia
 from bs4 import BeautifulSoup
 from telegram_bot.services import scraping_service
@@ -177,83 +177,60 @@ async def test_fetch_season_episode_count(mocker):
 
 
 @pytest.mark.asyncio
-async def test_scrape_1337x_parses_results(mocker):
-    # This is the response for the initial search results page
+async def test_scrape_generic_page_parses_results(mocker):
     search_html = """
     <table><tbody>
     <tr>
       <td>
         <a href="/cat">Movies</a>
-        <a href="/torrent/1/Sample.Movie.2023.1080p.x265/">Sample.Movie.2023.1080p.x265</a>
+        <a href="https://1337x.to/torrent/1/Sample.Movie.2023.1080p.x265/">Sample.Movie.2023.1080p.x265</a>
       </td>
       <td>10</td><td>0</td><td>0</td><td>1.5 GB</td><td><a>Anonymous</a></td>
     </tr>
     </tbody></table>
     """
 
-    # This is the required second response for the torrent detail page
-    detail_html = """
-    <div>
-      <a href="magnet:?xt=urn:btih:FAKEHASH">Magnet Download</a>
-    </div>
-    """
-
-    # The mock client now has TWO responses to give, and they will have a default status_code of 200
-    responses = [DummyResponse(text=search_html), DummyResponse(text=detail_html)]
-    mocker.patch("httpx.AsyncClient", return_value=DummyClient(responses))
-
-    context = Mock()
-    context.bot_data = {
-        "SEARCH_CONFIG": {
-            "preferences": {
-                "movies": {
-                    "codecs": {"x265": 5},
-                    "resolutions": {"1080p": 3},
-                    "uploaders": {"Anonymous": 2},
-                }
-            }
-        }
-    }
-
-    results = await scraping_service.scrape_1337x(
-        "Sample Movie 2023",
-        "movie",
-        "https://1337x.to/search/{query}/1/",
-        context,
-        base_query_for_filter="Sample Movie",
+    mocker.patch(
+        "telegram_bot.services.scraping_service._get_page_html",
+        AsyncMock(return_value=search_html),
+    )
+    mocker.patch(
+        "telegram_bot.services.scraping_service.find_magnet_link_on_page",
+        AsyncMock(return_value=["magnet:?xt=urn:btih:FAKEHASH"]),
     )
 
-    assert len(results) == 1
-    assert results[0]["title"] == "Sample.Movie.2023.1080p.x265"
-    assert results[0]["page_url"].startswith("magnet:")
-    assert results[0]["source"] == "1337x"
+    preferences = {
+        "codecs": {"x265": 5},
+        "resolutions": {"1080p": 3},
+        "uploaders": {"Anonymous": 2},
+    }
+
+    results = await scraping_service.scrape_generic_page(
+        "Sample Movie 2023",
+        "movie",
+        "https://1337x.to/search/Sample%20Movie%202023/1/",
+        preferences,
+    )
+
+    assert any(r["title"] == "Sample.Movie.2023.1080p.x265" for r in results)
+    assert any(r["page_url"].startswith("magnet:") for r in results)
+    assert any(r["seeders"] == 10 for r in results)
 
 
 @pytest.mark.asyncio
-async def test_scrape_1337x_no_results(mocker):
+async def test_scrape_generic_page_no_results(mocker):
     html = "<html><body>No results</body></html>"
-    responses = [DummyResponse(text=html)]
-    mocker.patch("httpx.AsyncClient", return_value=DummyClient(responses))
+    mocker.patch(
+        "telegram_bot.services.scraping_service._get_page_html", return_value=html
+    )
 
-    context = Mock()
-    context.bot_data = {
-        "SEARCH_CONFIG": {
-            "preferences": {
-                "movies": {
-                    "codecs": {},
-                    "resolutions": {},
-                    "uploaders": {},
-                }
-            }
-        }
-    }
+    preferences = {"codecs": {}, "resolutions": {}, "uploaders": {}}
 
-    results = await scraping_service.scrape_1337x(
+    results = await scraping_service.scrape_generic_page(
         "Sample",
         "movie",
-        "https://1337x.to/search/{query}/1/",
-        context,  # Pass the mock object here
-        base_query_for_filter="Sample Movie",
+        "https://1337x.to/search/Sample/1/",
+        preferences,
     )
 
     assert results == []
@@ -344,29 +321,29 @@ def test_strategy_find_direct_links_none():
 def test_strategy_contextual_search_keyword():
     html = '<a href="/download/123">Download Torrent</a>'
     soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_contextual_search(soup, "Query")
-    assert "/download/123" in links
+    results = scraping_service._strategy_contextual_search(soup, "Query")
+    assert any(item["page_url"] == "/download/123" for item in results)
 
 
 def test_strategy_contextual_search_query_match():
     html = '<a href="/details.php?id=456">My Show S01E01 1080p</a>'
     soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_contextual_search(soup, "My Show")
-    assert "/details.php?id=456" in links
+    results = scraping_service._strategy_contextual_search(soup, "My Show")
+    assert any(item["page_url"] == "/details.php?id=456" for item in results)
 
 
 def test_strategy_contextual_search_unrelated_keyword():
     html = '<a href="/about">About our download policy</a>'
     soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_contextual_search(soup, "My Show")
-    assert "/about" in links
+    results = scraping_service._strategy_contextual_search(soup, "My Show")
+    assert any(item["page_url"] == "/about" for item in results)
 
 
 def test_strategy_find_in_tables_single_match():
     html = '<table><tr><td>My Show</td><td><a href="/dl">Download</a></td></tr></table>'
     soup = BeautifulSoup(html, "lxml")
     results = scraping_service._strategy_find_in_tables(soup, "My Show")
-    assert "/dl" in results
+    assert any(item["page_url"] == "/dl" for item in results)
 
 
 def test_strategy_find_in_tables_multiple_matches():
@@ -378,7 +355,8 @@ def test_strategy_find_in_tables_multiple_matches():
     """
     soup = BeautifulSoup(html, "lxml")
     results = scraping_service._strategy_find_in_tables(soup, "My Show")
-    assert {"/e1", "/e2"}.issubset(results.keys())
+    urls = {item["page_url"] for item in results}
+    assert {"/e1", "/e2"}.issubset(urls)
 
 
 def test_strategy_find_in_tables_ignores_unrelated_tables():
@@ -388,39 +366,5 @@ def test_strategy_find_in_tables_ignores_unrelated_tables():
     """
     soup = BeautifulSoup(html, "lxml")
     results = scraping_service._strategy_find_in_tables(soup, "My Show")
-    assert "/dl" in results and "/x" not in results
-
-
-def test_score_candidate_links_prefers_magnet():
-    html = (
-        '<div><a href="magnet:?xt=urn:btih:1">Magnet</a></div>'
-        '<div><a href="/context">Download Torrent</a></div>'
-        '<table><tr><td>My Show</td><td><a href="/table">Link</a></td></tr></table>'
-    )
-    soup = BeautifulSoup(html, "lxml")
-    links = {"magnet:?xt=urn:btih:1", "/context", "/table"}
-    table_links = {"/table": 80.0}
-    best = scraping_service._score_candidate_links(links, "My Show", table_links, soup)
-    assert best == "magnet:?xt=urn:btih:1"
-
-
-def test_score_candidate_links_penalizes_ads():
-    html = (
-        '<div class="ad"><a href="/bad">My Show 1080p</a></div>'
-        '<div><a href="/good">My Show 1080p</a></div>'
-    )
-    soup = BeautifulSoup(html, "lxml")
-    links = {"/bad", "/good"}
-    best = scraping_service._score_candidate_links(links, "My Show", {}, soup)
-    assert best == "/good"
-
-
-def test_score_candidate_links_prefers_better_match():
-    html = (
-        '<div><a href="/high">My Show Episode</a></div>'
-        '<div><a href="/low">Another Show</a></div>'
-    )
-    soup = BeautifulSoup(html, "lxml")
-    links = {"/high", "/low"}
-    best = scraping_service._score_candidate_links(links, "My Show Episode", {}, soup)
-    assert best == "/high"
+    urls = {item["page_url"] for item in results}
+    assert "/dl" in urls and "/x" not in urls


### PR DESCRIPTION
## Summary
- route non-YTS providers through generic scraping with URL-encoded queries
- expand generic scraping strategies to capture torrent metadata and compute scores
- exercise new scraping logic and generic fallback in tests

## Testing
- `pre-commit run --files telegram_bot/services/scraping_service.py telegram_bot/services/search_logic.py tests/services/test_scraping_service.py tests/services/test_search_logic.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7d07a709883269676b655f685e4fe