### PR TITLE
feat: unify scraping with generic fallback

### DIFF
--- a/telegram_bot/services/search_logic.py
+++ b/telegram_bot/services/search_logic.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import re
+import urllib.parse
 from typing import Any
 from collections.abc import Callable, Coroutine
 
@@ -42,9 +43,7 @@ async def orchestrate_searches(
         )
         return []
 
-    # A dedicated scraper for EZTV would need to be created in the future.
     scraper_map: dict[str, ScraperFunction] = {
-        "1337x": scraping_service.scrape_1337x,
         "YTS.mx": scraping_service.scrape_yts,
     }
 
@@ -73,11 +72,6 @@ async def orchestrate_searches(
                 continue
 
             search_query = query
-            year = kwargs.get("year")
-
-            # Only append the year for the 1337x scraper.
-            if site_name == "1337x" and year:
-                search_query += f" {year}"
 
             scraper_func = scraper_map.get(site_name)
 
@@ -89,33 +83,28 @@ async def orchestrate_searches(
                 # Allow callers to override the string used for fuzzy filtering. This
                 # is useful for episode-specific searches where the query contains
                 # season/episode tokens that would otherwise reduce the match score.
-                base_filter = kwargs.get("base_query_for_filter", query)
                 extra_kwargs = {
                     k: v for k, v in kwargs.items() if k != "base_query_for_filter"
                 }
 
-                if site_name == "1337x":
-                    task = asyncio.create_task(
-                        scraper_func(
-                            search_query,
-                            media_type,
-                            site_url,
-                            context,
-                            base_query_for_filter=base_filter,
-                            **extra_kwargs,
-                        )
+                task = asyncio.create_task(
+                    scraper_func(
+                        search_query, media_type, site_url, context, **extra_kwargs
                     )
-                else:
-                    task = asyncio.create_task(
-                        scraper_func(
-                            search_query, media_type, site_url, context, **extra_kwargs
-                        )
-                    )
+                )
                 tasks.append(task)
             else:
-                logger.warning(
-                    f"[SEARCH] Configured site '{site_name}' has no corresponding scraper function. It will be ignored."
+                logger.info(f"[SEARCH] Using generic scraper for '{site_name}'.")
+                formatted_query = urllib.parse.quote_plus(search_query)
+                final_url = site_url.replace("{query}", formatted_query)
+
+                preferences = search_config.get("preferences", {}).get(config_key, {})
+                task = asyncio.create_task(
+                    scraping_service.scrape_generic_page(
+                        search_query, media_type, final_url, preferences
+                    )
                 )
+                tasks.append(task)
 
     if not tasks:
         logger.warning("[SEARCH] No enabled search sites found to orchestrate.")

--- a/tests/services/test_scraping_service.py
+++ b/tests/services/test_scraping_service.py
@@ -177,85 +177,44 @@ async def test_fetch_season_episode_count(mocker):
 
 
 @pytest.mark.asyncio
-async def test_scrape_1337x_parses_results(mocker):
-    # This is the response for the initial search results page
-    search_html = """
-    <table><tbody>
-    <tr>
-      <td>
-        <a href="/cat">Movies</a>
-        <a href="/torrent/1/Sample.Movie.2023.1080p.x265/">Sample.Movie.2023.1080p.x265</a>
-      </td>
-      <td>10</td><td>0</td><td>0</td><td>1.5 GB</td><td><a>Anonymous</a></td>
-    </tr>
-    </tbody></table>
-    """
-
-    # This is the required second response for the torrent detail page
-    detail_html = """
-    <div>
-      <a href="magnet:?xt=urn:btih:FAKEHASH">Magnet Download</a>
-    </div>
-    """
-
-    # The mock client now has TWO responses to give, and they will have a default status_code of 200
-    responses = [DummyResponse(text=search_html), DummyResponse(text=detail_html)]
-    mocker.patch("httpx.AsyncClient", return_value=DummyClient(responses))
-
-    context = Mock()
-    context.bot_data = {
-        "SEARCH_CONFIG": {
-            "preferences": {
-                "movies": {
-                    "codecs": {"x265": 5},
-                    "resolutions": {"1080p": 3},
-                    "uploaders": {"Anonymous": 2},
-                }
-            }
-        }
+async def test_scrape_generic_page_parses_results(mocker):
+    html = (
+        "<table><tr><td><a href='/dl'>Sample.Movie.2023.1080p.x265</a></td>"
+        "<td>10</td><td>5</td><td>1.5 GB</td><td>Anon</td></tr></table>"
+    )
+    mocker.patch(
+        "telegram_bot.services.scraping_service._get_page_html",
+        return_value=html,
+    )
+    prefs = {
+        "codecs": {"x265": 5},
+        "resolutions": {"1080p": 3},
+        "uploaders": {"Anon": 2},
     }
-
-    results = await scraping_service.scrape_1337x(
+    results = await scraping_service.scrape_generic_page(
         "Sample Movie 2023",
         "movie",
-        "https://1337x.to/search/{query}/1/",
-        context,
-        base_query_for_filter="Sample Movie",
+        "https://example.com/search",
+        prefs,
     )
-
     assert len(results) == 1
     assert results[0]["title"] == "Sample.Movie.2023.1080p.x265"
-    assert results[0]["page_url"].startswith("magnet:")
-    assert results[0]["source"] == "1337x"
+    assert results[0]["seeders"] == 10
 
 
 @pytest.mark.asyncio
-async def test_scrape_1337x_no_results(mocker):
-    html = "<html><body>No results</body></html>"
-    responses = [DummyResponse(text=html)]
-    mocker.patch("httpx.AsyncClient", return_value=DummyClient(responses))
-
-    context = Mock()
-    context.bot_data = {
-        "SEARCH_CONFIG": {
-            "preferences": {
-                "movies": {
-                    "codecs": {},
-                    "resolutions": {},
-                    "uploaders": {},
-                }
-            }
-        }
-    }
-
-    results = await scraping_service.scrape_1337x(
+async def test_scrape_generic_page_no_results(mocker):
+    mocker.patch(
+        "telegram_bot.services.scraping_service._get_page_html",
+        return_value="<html><body>No results</body></html>",
+    )
+    prefs = {"codecs": {}, "resolutions": {}, "uploaders": {}}
+    results = await scraping_service.scrape_generic_page(
         "Sample",
         "movie",
-        "https://1337x.to/search/{query}/1/",
-        context,  # Pass the mock object here
-        base_query_for_filter="Sample Movie",
+        "https://example.com/search",
+        prefs,
     )
-
     assert results == []
 
 
@@ -344,83 +303,54 @@ def test_strategy_find_direct_links_none():
 def test_strategy_contextual_search_keyword():
     html = '<a href="/download/123">Download Torrent</a>'
     soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_contextual_search(soup, "Query")
-    assert "/download/123" in links
+    results = scraping_service._strategy_contextual_search(soup, "Query")
+    urls = {r["page_url"] for r in results}
+    assert "/download/123" in urls
 
 
 def test_strategy_contextual_search_query_match():
     html = '<a href="/details.php?id=456">My Show S01E01 1080p</a>'
     soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_contextual_search(soup, "My Show")
-    assert "/details.php?id=456" in links
+    results = scraping_service._strategy_contextual_search(soup, "My Show")
+    urls = {r["page_url"] for r in results}
+    assert "/details.php?id=456" in urls
 
 
 def test_strategy_contextual_search_unrelated_keyword():
     html = '<a href="/about">About our download policy</a>'
     soup = BeautifulSoup(html, "lxml")
-    links = scraping_service._strategy_contextual_search(soup, "My Show")
-    assert "/about" in links
+    results = scraping_service._strategy_contextual_search(soup, "My Show")
+    urls = {r["page_url"] for r in results}
+    assert "/about" in urls
 
 
 def test_strategy_find_in_tables_single_match():
     html = '<table><tr><td>My Show</td><td><a href="/dl">Download</a></td></tr></table>'
     soup = BeautifulSoup(html, "lxml")
     results = scraping_service._strategy_find_in_tables(soup, "My Show")
-    assert "/dl" in results
+    urls = {r["page_url"] for r in results}
+    assert "/dl" in urls
 
 
 def test_strategy_find_in_tables_multiple_matches():
-    html = """
-    <table>
-      <tr><td>My Show S01E01</td><td><a href="/e1">DL</a></td></tr>
-      <tr><td>My Show S01E02</td><td><a href="/e2">DL</a></td></tr>
-    </table>
-    """
+    html = (
+        "<table>"
+        "<tr><td>My Show S01E01</td><td><a href='/e1'>DL</a></td></tr>"
+        "<tr><td>My Show S01E02</td><td><a href='/e2'>DL</a></td></tr>"
+        "</table>"
+    )
     soup = BeautifulSoup(html, "lxml")
     results = scraping_service._strategy_find_in_tables(soup, "My Show")
-    assert {"/e1", "/e2"}.issubset(results.keys())
+    urls = {r["page_url"] for r in results}
+    assert {"/e1", "/e2"}.issubset(urls)
 
 
 def test_strategy_find_in_tables_ignores_unrelated_tables():
-    html = """
-    <table><tr><td>Other</td><td><a href="/x">X</a></td></tr></table>
-    <table><tr><td>My Show</td><td><a href="/dl">Download</a></td></tr></table>
-    """
+    html = (
+        "<table><tr><td>Other</td><td><a href='/x'>X</a></td></tr></table>"
+        "<table><tr><td>My Show</td><td><a href='/dl'>Download</a></td></tr></table>"
+    )
     soup = BeautifulSoup(html, "lxml")
     results = scraping_service._strategy_find_in_tables(soup, "My Show")
-    assert "/dl" in results and "/x" not in results
-
-
-def test_score_candidate_links_prefers_magnet():
-    html = (
-        '<div><a href="magnet:?xt=urn:btih:1">Magnet</a></div>'
-        '<div><a href="/context">Download Torrent</a></div>'
-        '<table><tr><td>My Show</td><td><a href="/table">Link</a></td></tr></table>'
-    )
-    soup = BeautifulSoup(html, "lxml")
-    links = {"magnet:?xt=urn:btih:1", "/context", "/table"}
-    table_links = {"/table": 80.0}
-    best = scraping_service._score_candidate_links(links, "My Show", table_links, soup)
-    assert best == "magnet:?xt=urn:btih:1"
-
-
-def test_score_candidate_links_penalizes_ads():
-    html = (
-        '<div class="ad"><a href="/bad">My Show 1080p</a></div>'
-        '<div><a href="/good">My Show 1080p</a></div>'
-    )
-    soup = BeautifulSoup(html, "lxml")
-    links = {"/bad", "/good"}
-    best = scraping_service._score_candidate_links(links, "My Show", {}, soup)
-    assert best == "/good"
-
-
-def test_score_candidate_links_prefers_better_match():
-    html = (
-        '<div><a href="/high">My Show Episode</a></div>'
-        '<div><a href="/low">Another Show</a></div>'
-    )
-    soup = BeautifulSoup(html, "lxml")
-    links = {"/high", "/low"}
-    best = scraping_service._score_candidate_links(links, "My Show Episode", {}, soup)
-    assert best == "/high"
+    urls = {r["page_url"] for r in results}
+    assert "/dl" in urls and "/x" not in urls


### PR DESCRIPTION
## Summary
- use generic scraper whenever site lacks dedicated handler
- expand generic scraping to parse rows and score results
- drop legacy 1337x scraper and update tests

## Testing
- `ruff check telegram_bot/services/search_logic.py telegram_bot/services/scraping_service.py tests/services/test_scraping_service.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7dd1af3308326934b39d32c33de19