### PR TITLE
Add dedicated 1337x scraper

### DIFF
--- a/telegram_bot/services/search_logic.py
+++ b/telegram_bot/services/search_logic.py
@@ -43,9 +43,10 @@ async def orchestrate_searches(
         )
         return []
 
-    # A dedicated scraper for EZTV would need to be created in the future.
+    # Map site names to their dedicated scraper implementations
     scraper_map: dict[str, ScraperFunction] = {
         "YTS.mx": scraping_service.scrape_yts,
+        "1337x": scraping_service.scrape_1337x,
     }
 
     tasks = []


### PR DESCRIPTION
## Summary
- add 1337x scraping routine that pulls magnet links from result pages
- wire 1337x into search orchestration
- cover 1337x scraper with unit tests

## Testing
- `pre-commit run --files telegram_bot/services/scraping_service.py telegram_bot/services/search_logic.py tests/services/test_scraping_service.py`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa77f5d7348326975e271c18144a3b