### PR TITLE
Annotate torrent fetch results

### DIFF
--- a/telegram_bot/services/scraping_service.py
+++ b/telegram_bot/services/scraping_service.py
@@ -69,8 +69,8 @@ async def fetch_episode_title_from_wikipedia(
         main_page_url = main_page.url
 
         if main_page.title != show_title:
-            corrected_show_title = main_page.title
-            canonical_title = corrected_show_title
+            canonical_title = main_page.title
+            corrected_show_title = canonical_title
             logger.info(
                 f"[WIKI] Title was corrected: '{show_title}' -> '{canonical_title}'"
             )

--- a/telegram_bot/services/torrent_service.py
+++ b/telegram_bot/services/torrent_service.py
@@ -217,8 +217,12 @@ async def _fetch_and_parse_magnet_details(
     tasks = [fetch_one(link, i) for i, link in enumerate(magnet_links)]
     results = await asyncio.gather(*tasks)
 
-    parsed_choices = []
-    for result in filter(None, results):
+    parsed_choices: list[dict[str, Any]] = []
+    for result in results:
+        if result is None:
+            # A None result indicates the metadata fetch failed; skip this entry.
+            continue
+
         ti = result["ti"]
 
         # Filter out the torrent if it's too large before adding it to the choices


### PR DESCRIPTION
## Summary
- add explicit types and filtering when building parsed torrent choices
- assign Wikipedia canonical titles directly to avoid Optional type mismatch

## Testing
- `pre-commit run --files telegram_bot/services/torrent_service.py telegram_bot/services/scraping_service.py`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac240ec1c8326b2254c5bc03be8cd