### PR TITLE
Introduce TorrentData dataclass for scraper results

### DIFF
--- a/telegram_bot/services/torrent_data.py
+++ b/telegram_bot/services/torrent_data.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class TorrentData:
+    """Structured information for a scraped torrent.
+
+    Attributes:
+        title: Human-friendly torrent title.
+        magnet_url: Direct magnet link for the torrent.
+        seeders: Number of seeders reported by the site.
+        leechers: Number of leechers reported by the site.
+        size_bytes: Total size of the torrent in bytes.
+        source: Name of the site where the torrent was found.
+        score: Aggregate score used for ranking results.
+        uploader: Optional uploader name if provided by the source site.
+        codec: Optional codec information parsed from the title.
+        year: Optional release year parsed from the title.
+    """
+
+    title: str
+    magnet_url: str
+    seeders: int
+    leechers: int
+    size_bytes: int
+    source: str
+    score: int = 0
+    uploader: Optional[str] = None
+    codec: Optional[str] = None
+    year: Optional[int] = None

--- a/tests/services/test_scraping_service.py
+++ b/tests/services/test_scraping_service.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import wikipedia
 from bs4 import BeautifulSoup
 from telegram_bot.services import scraping_service
+from telegram_bot.services.torrent_data import TorrentData
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
@@ -224,9 +225,11 @@ async def test_scrape_1337x_parses_results(mocker):
     )
 
     assert len(results) == 1
-    assert results[0]["title"] == "Sample.Movie.2023.1080p.x265"
-    assert results[0]["page_url"].startswith("magnet:")
-    assert results[0]["source"] == "1337x"
+    result = results[0]
+    assert isinstance(result, TorrentData)
+    assert result.title == "Sample.Movie.2023.1080p.x265"
+    assert result.magnet_url.startswith("magnet:")
+    assert result.source == "1337x"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `TorrentData` dataclass for structured torrent info
- update 1337x scraper to emit `TorrentData` and adapt orchestration to handle dataclasses
- adjust tests for new data model

## Testing
- `uv run pre-commit run --files telegram_bot/services/scraping_service.py telegram_bot/services/search_logic.py telegram_bot/services/torrent_data.py tests/services/test_scraping_service.py`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac56b0c2483268351affd33ac7b17