### PR TITLE
Implement category-aware 1337x scraping with fuzzy filtering

### DIFF
--- a/telegram_bot/scrapers/configs/1337x.yaml
+++ b/telegram_bot/scrapers/configs/1337x.yaml
@@ -1,14 +1,29 @@
 site_name: "1337x"
 base_url: "https://1337x.to"
-search_path: "/search/{query}/1/"
-selectors:
-  results_container: "table.table-list tbody tr"
-  title: "td.name a:nth-of-type(2)"
+
+# Map internal media types to site categories
+category_mapping:
+  movie: Movies
+  tv: TV
+
+# Search path expects query, category, and page number
+search_path: "/category-search/{query}/{category}/{page}/"
+
+# CSS selectors for parsing the initial results page
+results_page_selectors:
+  rows: "table.table-list tbody tr"
+  name: "td.name a:nth-of-type(2)"
   details_page_link: "td.name a:nth-of-type(2)"
-  seeders: "td.seeds"
+  seeds: "td.seeds"
   leechers: "td.leeches"
   size: "td.size"
   uploader: "td.uploader a"
-  magnet_link: null
+
+# Selectors for elements on the torrent detail page
 details_page_selectors:
-  magnet_link: "a.btn-magnet"
+  magnet_url: "a.btn-magnet"
+
+# Optional features to refine results
+advanced_features:
+  enable_fuzzy_filter: true
+  fuzzy_filter_ratio: 85

--- a/telegram_bot/services/scraping_service.py
+++ b/telegram_bot/services/scraping_service.py
@@ -382,7 +382,10 @@ async def scrape_1337x(
         return []
 
     scraper = GenericTorrentScraper(site_config)
-    raw_results = await scraper.search(query)
+    base_filter = kwargs.get("base_query_for_filter")
+    raw_results = await scraper.search(
+        query, media_type, base_query_for_filter=base_filter
+    )
 
     results: list[dict[str, Any]] = []
     for item in raw_results:


### PR DESCRIPTION
## Summary
- make 1337x scraper category aware via YAML config and dynamic URL building
- fetch detail pages and add optional fuzzy filtering in GenericTorrentScraper
- pass media type through `scrape_1337x` and add test coverage

## Testing
- `pre-commit run --files telegram_bot/scrapers/configs/1337x.yaml telegram_bot/services/generic_torrent_scraper.py telegram_bot/services/scraping_service.py tests/services/test_scraping_service.py`
- `uv run pytest tests/services/test_scraping_service.py::test_scrape_1337x_parses_results tests/services/test_scrape_1337x_no_results tests/services/test_scrape_1337x_fuzzy_filter -q`
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'libtorrent')*

------
https://chatgpt.com/codex/tasks/task_e_68ab57d87c488326a1f2ad4ed1e34802