### PR TITLE
Include source site in results and refine search filtering

### DIFF
--- a/telegram_bot/services/download_manager.py
+++ b/telegram_bot/services/download_manager.py
@@ -620,6 +620,7 @@ async def handle_resume_request(update, context):
         download_data = active_downloads[chat_id_str]
         async with download_data["lock"]:
             download_data["is_paused"] = False
+            download_data.pop("cancellation_pending", None)
             logger.info(f"Resume request received for download for user {chat_id_str}.")
     else:
         await safe_edit_message(
@@ -646,6 +647,7 @@ async def handle_cancel_request(update, context):
     download_data = active_downloads[chat_id_str]
     async with download_data["lock"]:
         if query.data == "cancel_download":
+            download_data["cancellation_pending"] = True
             message_text = "Are you sure you want to cancel this download\\?"
             reply_markup = InlineKeyboardMarkup(
                 [
@@ -667,6 +669,7 @@ async def handle_cancel_request(update, context):
             )
 
         elif query.data == "cancel_confirm":
+            download_data.pop("cancellation_pending", None)
             logger.info(f"Cancellation confirmed for user {chat_id_str}.")
             if "task" in download_data and not download_data["task"].done():
                 download_data["task"].cancel()

--- a/telegram_bot/utils.py
+++ b/telegram_bot/utils.py
@@ -4,6 +4,7 @@ import math
 import os
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 from telegram import Message, Bot
 from telegram.error import BadRequest
@@ -26,6 +27,47 @@ def extract_first_int(text: str) -> int | None:
         return None
     match = re.search(r"\d+", text.strip())
     return int(match.group(0)) if match else None
+
+
+def get_site_name_from_url(url: str) -> str:
+    """Derives a human-friendly site name from a URL.
+
+    The function extracts the hostname, strips common subdomains such as
+    ``www`` and returns the uppercased base domain. If the hostname cannot be
+    determined the function falls back to ``"Unknown"``.
+
+    Parameters
+    ----------
+    url:
+        The URL to inspect.
+
+    Returns
+    -------
+    str
+        A short name representing the source site, e.g. ``"YTS"``.
+    """
+
+    if not url:
+        return "Unknown"
+
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme == "magnet":
+            return "MAGNET"
+
+        host = parsed.netloc
+        if not host:
+            return "Unknown"
+
+        host = host.split("@")[-1]
+        if host.startswith("www."):
+            host = host[4:]
+
+        base = host.split(".")[0]
+        return base.upper() if base else "Unknown"
+    except Exception:
+        # If urlparse or any string operations fail, return a safe default.
+        return "Unknown"
 
 
 async def safe_edit_message(bot_or_message: Bot | Message, text: str, **kwargs) -> None:

--- a/tests/services/test_search_logic.py
+++ b/tests/services/test_search_logic.py
@@ -5,6 +5,8 @@ from telegram_bot.services.search_logic import (
     _parse_codec,
     _parse_size_to_gb,
     score_torrent_result,
+    format_result_title,
+    group_and_filter_results,
 )
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
@@ -47,3 +49,19 @@ def test_score_torrent_result():
 
     no_match = score_torrent_result("Another 720p x264", "unknown", prefs, seeders=3)
     assert no_match == 3
+
+
+def test_format_result_title():
+    result = {"title": "Movie", "page_url": "https://yts.mx/t/1"}
+    assert format_result_title(result) == "[YTS] Movie"
+
+
+def test_group_and_filter_results():
+    results = [
+        {"title": "Sample Film 2020", "year": 2020},
+        {"title": "Sample Film 2021", "year": 2021},
+        {"title": "Different Movie 2020", "year": 2020},
+    ]
+    grouped = group_and_filter_results(results, "Sample Film")
+    assert len(grouped["results"]) == 2
+    assert grouped["years"] == ["2020", "2021"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,12 @@
 import sys
 from pathlib import Path
 import pytest
-from telegram_bot.utils import format_bytes, extract_first_int, parse_torrent_name
+from telegram_bot.utils import (
+    format_bytes,
+    extract_first_int,
+    parse_torrent_name,
+    get_site_name_from_url,
+)
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
@@ -63,3 +68,16 @@ def test_extract_first_int(text, expected_int):
 def test_parse_torrent_name(name, expected):
     """Verify that torrent names are parsed into the correct metadata."""
     assert parse_torrent_name(name) == expected
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://yts.mx/some/path", "YTS"),
+        ("https://1337x.to/torrent/123", "1337X"),
+        ("", "Unknown"),
+    ],
+)
+def test_get_site_name_from_url(url, expected):
+    """Ensure site names are extracted cleanly from URLs."""
+    assert get_site_name_from_url(url) == expected


### PR DESCRIPTION
## Summary
- show torrent source site in search results and utilities
- prevent status updates while cancel confirmation is pending
- refine preliminary search grouping to disambiguate years

## Testing
- `pre-commit run --files telegram_bot/utils.py telegram_bot/services/search_logic.py telegram_bot/workflows/search_workflow.py telegram_bot/services/download_manager.py tests/test_utils.py tests/services/test_search_logic.py tests/services/test_download_manager.py`
- `pytest tests/test_utils.py tests/services/test_search_logic.py tests/services/test_download_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abc155694083269bc75b51531ac842