### PR TITLE
Cache scraper configs and narrow parsing scope

### DIFF
--- a/telegram_bot/scrapers/configs/1337x.yaml
+++ b/telegram_bot/scrapers/configs/1337x.yaml
@@ -11,7 +11,8 @@ search_path: "/category-search/{query}/{category}/{page}/"
 
 # CSS selectors for parsing the initial results page
 results_page_selectors:
-  rows: "table.table-list tbody tr"
+  results_container: "table.table-list tbody"
+  rows: "tr"
   name: "td.name a:nth-of-type(2)"
   details_page_link: "td.name a:nth-of-type(2)"
   seeds: "td.seeds"

--- a/tests/services/test_generic_torrent_scraper_config_cache.py
+++ b/tests/services/test_generic_torrent_scraper_config_cache.py
@@ -1,0 +1,35 @@
+import yaml
+from pathlib import Path
+
+from telegram_bot.services import generic_torrent_scraper
+
+
+def test_load_site_config_uses_cache(tmp_path, monkeypatch):
+    """Loading the same config twice should hit the cache after the first read."""
+    config_path = tmp_path / "site.yaml"
+    config_data = {
+        "site_name": "TestSite",
+        "base_url": "https://example.com",
+        "search_path": "/{query}",
+        "category_mapping": {"movie": "Movies"},
+        "results_page_selectors": {"rows": "tr"},
+    }
+    config_path.write_text(yaml.safe_dump(config_data), encoding="utf-8")
+
+    # Ensure cache is empty before test
+    generic_torrent_scraper._config_cache.clear()
+
+    original_open = Path.open
+    call_count = {"count": 0}
+
+    def counting_open(self, *args, **kwargs):
+        call_count["count"] += 1
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", counting_open)
+
+    first = generic_torrent_scraper.load_site_config(config_path)
+    second = generic_torrent_scraper.load_site_config(config_path)
+
+    assert first is second
+    assert call_count["count"] == 1


### PR DESCRIPTION
## Summary
- cache loaded YAML scraper configs to avoid repeated disk access
- scope HTML parsing to a results container before row selection
- document caching with new unit test

## Testing
- `uv run pre-commit run --files telegram_bot/services/generic_torrent_scraper.py telegram_bot/scrapers/configs/1337x.yaml tests/services/test_generic_torrent_scraper_config_cache.py`
- `pytest tests/services/test_generic_torrent_scraper_config_cache.py -q`
- `pytest -q` *(fails: fixture 'mocker' not found, many tests error)*

------
https://chatgpt.com/codex/tasks/task_e_68ad40b7f63c8326b32a8d610a867148