### PR TITLE
Optimize torrent scraper performance

### DIFF
--- a/tests/services/test_scraping_service.py
+++ b/tests/services/test_scraping_service.py
@@ -294,16 +294,13 @@ async def test_scrape_1337x_fuzzy_filter(mocker):
     detail_good = """
     <div><a class="btn-magnet" href="magnet:?xt=urn:btih:GOOD">Magnet</a></div>
     """
-    detail_bad = """
-    <div><a class="btn-magnet" href="magnet:?xt=urn:btih:BAD">Magnet</a></div>
-    """
 
     responses = [
         DummyResponse(text=search_html),
         DummyResponse(text=detail_good),
-        DummyResponse(text=detail_bad),
     ]
-    mocker.patch("httpx.AsyncClient", return_value=DummyClient(responses))
+    client = DummyClient(responses)
+    mocker.patch("httpx.AsyncClient", return_value=client)
 
     context = Mock()
     context.bot_data = {
@@ -328,6 +325,8 @@ async def test_scrape_1337x_fuzzy_filter(mocker):
 
     assert len(results) == 1
     assert results[0]["title"] == "Sample.Movie.2023.1080p.x265"
+    # Only the search page and one detail page should have been requested
+    assert client._index == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Parse search result rows without hitting detail pages and resolve magnet links in parallel only for filtered results
- Add optional `details_link` in `TorrentData` to defer magnet fetches
- Update 1337x scraping test to assert only one detail page is requested

## Testing
- `uv run --with pre-commit pre-commit run --files telegram_bot/services/generic_torrent_scraper.py tests/services/test_scraping_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad46fa2f8883269d4d252e05a1eed2