### PR TITLE
Refactor scraper to parse only top torrents

### DIFF
--- a/telegram_bot/scrapers/configs/1337x.yaml
+++ b/telegram_bot/scrapers/configs/1337x.yaml
@@ -11,11 +11,18 @@ search_path: "/category-search/{query}/{category}/{page}/"
 
 # CSS selectors for parsing the initial results page
 results_page_selectors:
+  # The table body contains all search results. Limiting the scope avoids
+  # parsing unrelated parts of the page.
   results_container: "table.table-list tbody"
-  rows: "tr"
+  # Each <tr> inside the container represents a single torrent result.
+  result_row: "tr"
+  # Granular selectors used by the scraper when extracting data from a row.
   name: "td.name a:nth-of-type(2)"
-  details_page_link: "td.name a:nth-of-type(2)"
-  seeds: "td.seeds"
+  # 1337x exposes only a link to a detail page on the search results. The
+  # scraper will treat this as a magnet link if it already uses the magnet
+  # scheme or as a detail page otherwise.
+  magnet: "td.name a[href^='/torrent/']"
+  seeders: "td.seeds"
   leechers: "td.leeches"
   size: "td.size"
   uploader: "td.uploader a"

--- a/telegram_bot/services/scraping_service.py
+++ b/telegram_bot/services/scraping_service.py
@@ -353,6 +353,7 @@ async def scrape_1337x(
     media_type: str,
     search_url_template: str,
     context: ContextTypes.DEFAULT_TYPE,
+    limit: int = 15,
     **kwargs,
 ) -> list[dict[str, Any]]:
     """Scrape 1337x using the generic scraper framework."""
@@ -384,7 +385,7 @@ async def scrape_1337x(
     scraper = GenericTorrentScraper(site_config)
     base_filter = kwargs.get("base_query_for_filter")
     raw_results = await scraper.search(
-        query, media_type, base_query_for_filter=base_filter
+        query, media_type, base_query_for_filter=base_filter, limit=limit
     )
 
     results: list[dict[str, Any]] = []

--- a/tests/services/test_generic_torrent_scraper_filtering.py
+++ b/tests/services/test_generic_torrent_scraper_filtering.py
@@ -12,10 +12,10 @@ async def test_two_stage_filtering_keeps_consensus_results(mocker):
         "search_path": "/search/{query}/{category}/{page}/",
         "category_mapping": {"movie": "movies"},
         "results_page_selectors": {
-            "rows": "tr",
+            "result_row": "tr",
             "name": "td.name a",
-            "magnet_url": "td.name a",
-            "seeds": "td.seeds",
+            "magnet": "td.name a",
+            "seeders": "td.seeds",
             "leechers": "td.leeches",
             "size": "td.size",
         },

--- a/tests/services/test_generic_torrent_scraper_magnet.py
+++ b/tests/services/test_generic_torrent_scraper_magnet.py
@@ -15,10 +15,10 @@ async def test_search_parses_magnet_link_from_detail_page(mocker):
         "search_path": "/search/{query}/{category}/{page}/",
         "category_mapping": {"movie": "movies"},
         "results_page_selectors": {
-            "rows": "tr",
+            "result_row": "tr",
             "name": "td.name a",
-            "details_page_link": "td.name a",
-            "seeds": "td.seeds",
+            "magnet": "td.name a",
+            "seeders": "td.seeds",
             "leechers": "td.leeches",
             "size": "td.size",
         },

--- a/tests/services/test_generic_torrent_scraper_topn.py
+++ b/tests/services/test_generic_torrent_scraper_topn.py
@@ -1,0 +1,75 @@
+from bs4 import BeautifulSoup
+
+from telegram_bot.services.generic_torrent_scraper import GenericTorrentScraper
+
+
+def _build_scraper() -> GenericTorrentScraper:
+    site_config = {
+        "site_name": "TestSite",
+        "base_url": "https://example.com",
+        "search_path": "/search/{query}/{category}/{page}/",
+        "category_mapping": {"movie": "movies"},
+        "results_page_selectors": {
+            "result_row": "tr",
+            "name": "td.name a",
+            "magnet": "td.name a",
+            "seeders": "td.seeds",
+            "leechers": "td.leeches",
+            "size": "td.size",
+            "uploader": "td.uploader a",
+        },
+    }
+    return GenericTorrentScraper(site_config)
+
+
+def test_extract_data_from_row() -> None:
+    scraper = _build_scraper()
+    row_html = (
+        "<tr>"
+        '<td class="name"><a href="magnet:?xt=1">Example</a></td>'
+        '<td class="seeds">5</td>'
+        '<td class="leeches">2</td>'
+        '<td class="size">1 GB</td>'
+        '<td class="uploader"><a>Uploader</a></td>'
+        "</tr>"
+    )
+    row = BeautifulSoup(row_html, "lxml").select_one("tr")
+
+    data = scraper._extract_data_from_row(row)  # type: ignore[arg-type]
+    assert data is not None
+    assert data.name == "Example"
+    assert data.seeders == 5
+    assert data.uploader == "Uploader"
+
+    malformed = BeautifulSoup("<tr><td></td></tr>", "lxml").select_one("tr")
+    assert scraper._extract_data_from_row(malformed) is None  # type: ignore[arg-type]
+
+
+def test_parse_and_select_top_results() -> None:
+    scraper = _build_scraper()
+    html = (
+        "<tbody>"
+        "<tr>"
+        '<td class="name"><a href="magnet:?a">A</a></td>'
+        '<td class="seeds">1</td><td class="leeches">0</td><td class="size">1 GB</td>'
+        '<td class="uploader"><a>U</a></td>'
+        "</tr>"
+        "<tr>"
+        '<td class="name"><a href="magnet:?b">B</a></td>'
+        '<td class="seeds">5</td><td class="leeches">0</td><td class="size">1 GB</td>'
+        '<td class="uploader"><a>U</a></td>'
+        "</tr>"
+        "<tr>"
+        '<td class="name"><a href="magnet:?c">C</a></td>'
+        '<td class="seeds">3</td><td class="leeches">0</td><td class="size">1 GB</td>'
+        '<td class="uploader"><a>U</a></td>'
+        "</tr>"
+        "</tbody>"
+    )
+    search_area = BeautifulSoup(html, "lxml")
+
+    top_results = scraper._parse_and_select_top_results(search_area, limit=2)
+    assert len(top_results) == 2
+    assert [r.name for r in top_results] == ["B", "C"]
+    assert top_results[0].seeders == 5
+    assert top_results[1].seeders == 3


### PR DESCRIPTION
## Summary
- add granular selectors for 1337x results page
- limit `GenericTorrentScraper` to top seeded torrents with new helper methods
- allow scrape_1337x to forward a configurable limit
- add tests for row parsing, top-N selection and limit propagation

## Testing
- `pre-commit run --files telegram_bot/scrapers/configs/1337x.yaml telegram_bot/services/generic_torrent_scraper.py telegram_bot/services/scraping_service.py tests/services/test_generic_torrent_scraper_filtering.py tests/services/test_generic_torrent_scraper_magnet.py tests/services/test_generic_torrent_scraper_topn.py tests/services/test_scraping_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae9b12f6c88326b6d0cc93e0410469